### PR TITLE
docs: add AGENTS.md and CODEX.md for multi-agent coordination

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,137 @@
+# EconLife — Multi-Agent Coordination
+
+This file defines the rules for parallel AI agent work on EconLife.
+Both Claude Code and Codex (and any future agents) follow these rules.
+
+---
+
+## Active Agents
+
+| Agent       | Context Files Read          |
+|-------------|-----------------------------|
+| Claude Code | CLAUDE.md, AGENTS.md        |
+| Codex       | CODEX.md, AGENTS.md         |
+
+Both agents also read per-module `CLAUDE.md` files in `simulation/modules/[name]/`
+and interface specs in `docs/interfaces/[name]/INTERFACE.md`.
+
+---
+
+## The Parallel Work Rule
+
+Each agent session works on exactly **one module**. Before starting work,
+claim the module by creating a branch. If a branch already exists for
+that module, do not work on it — pick a different module.
+
+---
+
+## Branch Naming Convention
+
+```
+{agent}/{module-name}-{task}
+```
+
+Examples:
+- `claude/evidence-implementation`
+- `codex/supply-chain-stub`
+- `claude/production-optimization`
+- `codex/npc-behavior-lazy-eval`
+
+Check for existing branches before starting:
+```bash
+git fetch origin
+git branch -r | grep -i "{module-name}"
+```
+
+---
+
+## Module Ownership During a Session
+
+While a branch exists for a module, that module is **claimed**.
+Files owned by a claimed module:
+
+```
+simulation/modules/[module_name]/*
+simulation/tests/unit/[module_name]_test.cpp
+simulation/tests/integration/*[module_name]*
+```
+
+Do NOT modify files in a claimed module from another session.
+
+---
+
+## Shared Files — Coordination Required
+
+These files must not be modified by agents without human approval:
+
+- `simulation/core/*`
+- `simulation/modules/register_base_game_modules.*`
+- `CMakeLists.txt` (root and simulation/)
+- `CLAUDE.md`, `AGENTS.md`, `CODEX.md`
+- `docs/design/*`
+- `docs/interfaces/*/INTERFACE.md`
+
+---
+
+## Commit Message Format
+
+```
+[module_name]: description
+```
+
+Examples:
+- `[production]: implement batch processing`
+- `[evidence]: add propagation delay tests`
+- `[supply_chain]: fix determinism in route calculation`
+
+---
+
+## Build and Test Commands
+
+```bash
+# Configure
+cmake -B build -DCMAKE_BUILD_TYPE=Debug -DECONLIFE_BUILD_TESTS=ON
+
+# Build
+cmake --build build -j
+
+# Run all unit tests
+ctest --test-dir build -L "module" --output-on-failure
+
+# Run specific module tests
+ctest --test-dir build -R "[module_name]" --output-on-failure
+
+# Determinism tests
+ctest --test-dir build -L "determinism" --output-on-failure
+
+# Format check
+find simulation/ -name "*.h" -o -name "*.cpp" | xargs clang-format --dry-run --Werror
+```
+
+---
+
+## Before Pushing / Creating a PR
+
+1. All unit tests pass (the full suite, not just your module)
+2. Determinism tests pass
+3. Code is clang-format clean
+4. No `simulation/` -> `ui/` imports
+5. No `std::rand`, `srand`, `std::random_device`, or system time calls in `simulation/`
+6. Commit messages follow the format above
+
+---
+
+## Merge Target
+
+All PRs target `main`. One module per PR. Squash merge preferred.
+
+---
+
+## Dependency Graph
+
+Lower-tier modules must be implemented and merged before higher-tier
+modules that depend on them.
+
+- Tier assignments: `docs/design/EconLife_Feature_Tier_List.md`
+- Per-module dependencies: each module's `CLAUDE.md` lists `runs_after` / `runs_before`
+- Full architecture: `docs/design/EconLife_Technical_Design_v29.md`

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,0 +1,121 @@
+# EconLife — Codex Developer Context
+
+## Read First
+
+- **AGENTS.md** — Multi-agent coordination rules (branch naming, module claiming, shared file rules)
+- **CLAUDE.md** — Full project context (all rules apply to you too)
+- This file contains Codex-specific operational instructions.
+
+---
+
+## What This Project Is
+
+A deterministic C++20 agent-based economic simulation game. The simulation
+runs headlessly at one tick per in-game day. The UI observes simulation
+state only. January 2000 start date with dynamic era progression.
+
+---
+
+## Inviolable Rules
+
+1. `simulation/` **never** imports from `ui/`
+2. All randomness goes through `simulation/core/rng/DeterministicRNG`
+3. Same seed + same inputs = same outputs (determinism is required)
+4. Interface spec (`docs/interfaces/[module]/INTERFACE.md`) wins over implementation
+5. No raw pointers in module code — use smart pointers or pool allocation
+6. Floating-point accumulations use canonical sort order (`good_id` asc, `province_id` asc)
+
+---
+
+## Before You Write Code
+
+1. Read the module's `CLAUDE.md` in `simulation/modules/[name]/`
+2. Read the interface spec in `docs/interfaces/[name]/INTERFACE.md`
+3. Understand `runs_after` / `runs_before` dependencies
+4. Check the module's existing implementation files
+5. Check for existing branches on this module: `git branch -r | grep -i "[module]"`
+
+---
+
+## Build Commands
+
+```bash
+# Configure
+cmake -B build -DCMAKE_BUILD_TYPE=Debug -DECONLIFE_BUILD_TESTS=ON
+
+# Build
+cmake --build build -j
+
+# Run all tests
+ctest --test-dir build --output-on-failure
+
+# Run specific module tests
+ctest --test-dir build -R "[module_name]" --output-on-failure
+
+# Determinism tests
+ctest --test-dir build -L "determinism" --output-on-failure
+
+# Format code
+clang-format -i simulation/modules/[module]/*.cpp simulation/modules/[module]/*.h
+
+# Format check (dry run)
+find simulation/ -name "*.h" -o -name "*.cpp" | xargs clang-format --dry-run --Werror
+```
+
+---
+
+## Module Structure
+
+Follow the existing pattern in `simulation/modules/`:
+
+```
+simulation/modules/[name]/
+  CLAUDE.md              — module context (read this, do not modify)
+  CMakeLists.txt         — build config
+  [name]_module.h        — module class header (implements ITickModule)
+  [name]_module.cpp      — implementation
+  [name]_types.h         — data types (if needed)
+```
+
+---
+
+## Session Workflow
+
+1. Create branch: `codex/[module-name]-[task]`
+2. Read module `CLAUDE.md` and `INTERFACE.md`
+3. Implement / fix / optimize
+4. Run tests, fix failures
+5. Run clang-format
+6. Commit with format: `[module_name]: description`
+7. Push and create PR targeting `main`
+
+---
+
+## What NOT to Do
+
+- Do not modify interface specs (`docs/interfaces/`)
+- Do not modify shared core code (`simulation/core/`) without human approval
+- Do not modify other modules' files
+- Do not expand scope beyond the assigned task
+- Do not use `std::rand`, `srand`, `std::random_device`, or system time in `simulation/`
+- Do not guess when the spec is ambiguous — flag it in the PR description
+- Do not modify `CLAUDE.md`, `AGENTS.md`, or `CODEX.md`
+
+---
+
+## Key Design Documents
+
+- GDD v1.7: `docs/design/EconLife_GDD.md`
+- Technical Design v29: `docs/design/EconLife_Technical_Design_v29.md`
+- Feature Tier List: `docs/design/EconLife_Feature_Tier_List.md`
+- AI Development Plan: `docs/design/EconLife_AI_Development_Plan_updated.md`
+- Commodities & Factories: `docs/design/EconLife_Commodities_and_Factories_v23.md`
+
+---
+
+## Who to Ask When Unsure
+
+- Design questions: Read GDD v1.7
+- Architecture questions: Read Technical_Design_v29.md
+- Scope questions: Read Feature_Tier_List.md
+- If still unclear: Do not guess. Flag for human review in the PR description.


### PR DESCRIPTION
Enables Claude Code and Codex to work on separate modules in parallel.
AGENTS.md defines coordination rules (branch claiming, shared file
protection, commit conventions). CODEX.md provides Codex-specific
context analogous to the existing CLAUDE.md.

https://claude.ai/code/session_01EqR8q49QctVUMJEq6veueB