### PR TITLE
Audit cleanup, contract perf gate, and validation refactors

### DIFF
--- a/.github/scripts/check_benchmark_threshold.py
+++ b/.github/scripts/check_benchmark_threshold.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Parse Catch2 XML benchmark output and fail when a gated benchmark
+exceeds its threshold.
+
+Catch2 v3 emits each benchmark result as a `BenchmarkResults` element
+under the parent `TestCase`. The `mean` child element carries the mean
+in nanoseconds. We treat the mean as the gate metric.
+
+Usage:
+  check_benchmark_threshold.py <xml_path> [<benchmark_name> <threshold_ms> ...]
+
+Each (name, threshold_ms) pair fails the script when
+`mean(name) > threshold_ms`. Pairs are matched on a case-insensitive
+substring of the benchmark name.
+
+Always prints the parsed results table for transparency, regardless of
+pass/fail.
+"""
+
+from __future__ import annotations
+
+import sys
+import xml.etree.ElementTree as ET
+
+
+def parse_results(xml_path: str) -> list[tuple[str, float]]:
+    """Return [(benchmark_name, mean_ms), ...] from a Catch2 XML report."""
+    tree = ET.parse(xml_path)
+    root = tree.getroot()
+    results: list[tuple[str, float]] = []
+    for br in root.iter("BenchmarkResults"):
+        name = br.attrib.get("name", "<unnamed>")
+        mean_el = br.find("mean")
+        if mean_el is None or "value" not in mean_el.attrib:
+            continue
+        mean_ns = float(mean_el.attrib["value"])
+        results.append((name, mean_ns / 1_000_000.0))
+    return results
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2 or (len(argv) - 2) % 2 != 0:
+        print(__doc__, file=sys.stderr)
+        return 2
+    xml_path = argv[1]
+    gates: list[tuple[str, float]] = []
+    for i in range(2, len(argv), 2):
+        gates.append((argv[i].lower(), float(argv[i + 1])))
+
+    results = parse_results(xml_path)
+    if not results:
+        print(f"No BenchmarkResults found in {xml_path}", file=sys.stderr)
+        return 2
+
+    print("Benchmark results (mean):")
+    for name, mean_ms in results:
+        print(f"  {name}: {mean_ms:.3f} ms")
+    print()
+
+    failed = False
+    for needle, threshold_ms in gates:
+        matches = [(n, m) for n, m in results if needle in n.lower()]
+        if not matches:
+            print(f"FAIL: no benchmark matched '{needle}'", file=sys.stderr)
+            failed = True
+            continue
+        for name, mean_ms in matches:
+            if mean_ms > threshold_ms:
+                print(
+                    f"FAIL: '{name}' mean {mean_ms:.3f} ms > threshold {threshold_ms:.3f} ms",
+                    file=sys.stderr,
+                )
+                failed = True
+            else:
+                print(
+                    f"OK:   '{name}' mean {mean_ms:.3f} ms <= threshold {threshold_ms:.3f} ms"
+                )
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,12 +19,33 @@ jobs:
       - name: Build
         run: cmake --build build --config Release -j
 
-      - name: Run benchmarks
+      # Run the contract benchmark only — gating on the full benchmark
+      # suite is too noisy on shared runners. Other benchmarks are still
+      # runnable locally for debugging via `ctest -L benchmark`.
+      - name: Run contract benchmark
         run: |
-          ctest --test-dir build -C Release -L "benchmark" --output-on-failure || true
-          echo "Benchmark results above. Compare against baseline for regressions."
+          mkdir -p benchmark-results
+          ./build/simulation/tests/benchmarks/econlife_benchmarks "[contract]" \
+            --reporter xml --out benchmark-results/results.xml \
+            --reporter console::out=-
 
-      # TODO: When benchmarks produce actual timings, add:
-      # - Baseline comparison against previous main branch results
-      # - PR comment with performance delta
-      # - Fail if any benchmark regresses by > 20%
+      - name: Check threshold
+        # Threshold is 200 ms — the target contract from CLAUDE.md
+        # ("< 200ms on 6 cores"). Local Release runs at ~6 ms, so this
+        # gives ~33x headroom for shared-runner noise while still
+        # asserting the design contract. Loosen if CI runners turn out
+        # noisier than that; tighten once 20+ runs of baseline data
+        # have been collected. The "contract:" substring matches the
+        # benchmark name in tests/benchmarks/tick_benchmark.cpp.
+        run: |
+          python3 .github/scripts/check_benchmark_threshold.py \
+            benchmark-results/results.xml \
+            "contract:" 200
+
+      - name: Upload benchmark results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results-${{ github.sha }}
+          path: benchmark-results/results.xml
+          retention-days: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Run scenario tests
         run: ctest --test-dir build -C ${{ matrix.build_type }} -L "scenario" --output-on-failure
 
+      - name: Run integration tests
+        run: ctest --test-dir build -C ${{ matrix.build_type }} -L "integration" --output-on-failure
+
   dependency-direction-lint:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Build output
 build/
+build-*/
 build_*/
 out/
 cmake-build-*/

--- a/docs/CODEBASE_AUDIT_REPORT.md
+++ b/docs/CODEBASE_AUDIT_REPORT.md
@@ -95,10 +95,17 @@ grows past a few hundred entries or until a real collision surfaces.
 
 ### L6. Tier comments in `register_base_game_modules.cpp` drift
 
-**Status:** Open. Cosmetic — topological sort handles the real order.
-The "Tier N: Depends on X" comments are a registration aid; some no
-longer match the dependency declarations the modules return from
-`runs_after()`. Either update the comments or generate them.
+**Status:** Resolved in this commit. The tier-numbered "Depends on X"
+comments invited drift the moment a module added a new
+`runs_after()` entry. They have been replaced with role-based
+groupings (production/markets, finance, NPC behavior, evidence,
+criminal economy, infrastructure) that describe what the section
+*is* rather than where it sits in a dependency hierarchy. The
+header comment at the top of the file points readers to
+`runs_after()` / `runs_before()` as the source of truth and notes
+that registration order only matters as a tiebreaker for the
+topological sort. Verified all 1312 tests still pass after the
+reordering.
 
 ---
 
@@ -128,6 +135,7 @@ longer match the dependency declarations the modules return from
 | **L1** weak good-id hash (quick) | (this commit) | Three duplicated `hash * 31 + c` implementations consolidated into `core/good_id_hash.h` (FNV-1a). Verified zero collisions on base_game. Long-form fix (catalog numeric ids) still open. |
 | **L8** no CI perf gate | `3e53cd7` | `benchmark.yml` now runs the all-modules contract benchmark and gates on a 200 ms threshold; results uploaded as artifact. |
 | **H5** linear-scan lookups (per-id) | `3a40d34` | drain_deferred_work, labor_market::find_employment, npc_spending::get_buyer_type now use hash-map indices. Filter-shape scans (22 NPC iterations) remain. |
+| **L6** register-tier comment drift | (this commit) | Tier-numbered comments replaced with role-based section groupings; runs_after()/runs_before() declared as the source of truth. |
 | Supply chain transit-delay bypass | `32ae755` | Tier A. Was not in the original report but discovered during verification. |
 
 ---
@@ -136,5 +144,4 @@ longer match the dependency declarations the modules return from
 
 1. **L1 catalog migration** — proper fix: thread `GoodsCatalog&` through Production / SupplyChain / SeasonalAgriculture and use `numeric_id` instead of hashing. Removes the hash entirely. Defer until justified by collision or scale.
 2. **H5 filter-shape scans** — 22 `for npc : significant_npcs` iterations. Needs province-bucketed NPC lists or an iteration helper. Design pass first.
-3. **L6 — register-tier comments.** Cosmetic; do alongside any module-registration touch.
-4. **M3 stub handlers.** Resolve naturally as each consuming module lands.
+3. **M3 stub handlers.** Resolve naturally as each consuming module lands.

--- a/docs/CODEBASE_AUDIT_REPORT.md
+++ b/docs/CODEBASE_AUDIT_REPORT.md
@@ -68,35 +68,30 @@ modules:
 **Fix:** No standalone fix; resolved as each consuming module lands.
 Track via the per-handler `// Will be implemented in...` comments.
 
-### L1. `good_id_from_string` uses a weak hash
+### L1. `good_id_from_string` weak hash — partially fixed
 
-**Status:** Open.
-**File:** `simulation/modules/production/production_module.cpp:68-75`.
+**Status:** Quick fix shipped; proper fix still open.
+**File:** `simulation/core/good_id_hash.h` (new).
 
-`hash * 31 + c` (Java string hash). Fine for the current ~252 goods, but
-string collisions are not bounded. If two recipe-referenced good ids
-collide, the bug surfaces as silently merged supply/demand on the wrong
-market — hard to diagnose.
+Quick fix (this branch): the three modules that hashed good_ids
+(production, supply_chain, seasonal_agriculture) were duplicating the
+same Java-style `hash * 31 + c` function with explicit "must match"
+comments. They now route through a single `econlife::good_id_hash`
+helper that uses FNV-1a (32-bit). Verified zero collisions on the
+247-good base_game catalog with both old and new hashes.
 
-**Fix:** Replace with FNV-1a or wyhash; or, better, change `good_id` to
-a stable integer assigned at goods-catalog load time and stored in a
-single source of truth, removing the per-call hash entirely.
+Proper fix (open): change `good_id` to a stable integer assigned at
+goods-catalog load time (`GoodDefinition::numeric_id` already exists)
+and route every Recipe → MarketDelta path through the catalog instead
+of hashing strings. This needs a `GoodsCatalog&` reference threaded
+through ProductionModule / SupplyChainModule / SeasonalAgricultureModule
+and a small migration in their tests. Defer until the goods catalog
+grows past a few hundred entries or until a real collision surfaces.
 
 ### L3. Brittle delta merge in tick_orchestrator
 
 **Status:** Open. Tracked as **B1** in
 `docs/plans/2026-04-25-tier-b-followups.md`.
-
-### L5. Goods CSV not cross-validated against recipe inputs/outputs
-
-**Status:** Open. No load-time check that every recipe `good_id` exists
-in the goods catalog. A typo in a recipe CSV produces a silently-zero
-production rate at runtime.
-
-**Fix:** In `recipe_catalog.cpp` (or a follow-up `validate_packages()`
-call after all catalogs load), iterate every recipe's inputs/outputs
-and assert each `good_id` exists in `GoodsCatalog`. Fail fast at
-package load.
 
 ### L6. Tier comments in `register_base_game_modules.cpp` drift
 
@@ -104,11 +99,6 @@ package load.
 The "Tier N: Depends on X" comments are a registration aid; some no
 longer match the dependency declarations the modules return from
 `runs_after()`. Either update the comments or generate them.
-
-### L8. No CI performance gate
-
-**Status:** Open. Tracked as **B3** in
-`docs/plans/2026-04-25-tier-b-followups.md`.
 
 ---
 
@@ -134,17 +124,17 @@ longer match the dependency declarations the modules return from
 | **L2** CrossProvinceDeltaBuffer thread safety | `a9b3660` | Pushes go through per-province DeltaBuffer; orchestrator merges into `world.cross_province_delta_buffer` from the main thread (apply_deltas.cpp:564). |
 | **L4** player_delta missed merge | (orchestrator refactor) | Merge added at tick_orchestrator.cpp:211-228. |
 | **L7** NPCTravelStatus literal cast | `32ae755` | Tier A. |
+| **L5** recipe ↔ goods cross-validation | `4ed4ebe` | `RecipeCatalog::validate_against_goods`; world_generator logs missing references at load. Verified clean on base_game (247 goods, 102 recipes). |
+| **L1** weak good-id hash (quick) | (this commit) | Three duplicated `hash * 31 + c` implementations consolidated into `core/good_id_hash.h` (FNV-1a). Verified zero collisions on base_game. Long-form fix (catalog numeric ids) still open. |
+| **L8** no CI perf gate | `3e53cd7` | `benchmark.yml` now runs the all-modules contract benchmark and gates on a 200 ms threshold; results uploaded as artifact. |
+| **H5** linear-scan lookups (per-id) | `3a40d34` | drain_deferred_work, labor_market::find_employment, npc_spending::get_buyer_type now use hash-map indices. Filter-shape scans (22 NPC iterations) remain. |
 | Supply chain transit-delay bypass | `32ae755` | Tier A. Was not in the original report but discovered during verification. |
 
 ---
 
 ## Recommended Priority Order (refreshed)
 
-1. **B2 — refresh this report** (this PR).
-2. **H5 — linear-scan lookups.** Largest perf risk; blocks meaningful CI perf gate.
-3. **B1 — `DeltaBuffer::merge_from`.** Mechanical refactor; pays for itself the next time someone adds a delta type.
-4. **L5 — recipe ↔ goods cross-validation.** Cheap, prevents silent typo bugs in modder content.
-5. **L1 — better good-id hash (or integer ids).** Lower risk than L5 today; revisit when goods catalog grows past a few hundred entries.
-6. **B3 — CI perf gate.** After H5; otherwise gate calibrates against known-slow code.
-7. **L6 — register-tier comments.** Cosmetic; do alongside any module-registration touch.
-8. **M3 stub handlers.** Resolve naturally as each consuming module lands.
+1. **L1 catalog migration** — proper fix: thread `GoodsCatalog&` through Production / SupplyChain / SeasonalAgriculture and use `numeric_id` instead of hashing. Removes the hash entirely. Defer until justified by collision or scale.
+2. **H5 filter-shape scans** — 22 `for npc : significant_npcs` iterations. Needs province-bucketed NPC lists or an iteration helper. Design pass first.
+3. **L6 — register-tier comments.** Cosmetic; do alongside any module-registration touch.
+4. **M3 stub handlers.** Resolve naturally as each consuming module lands.

--- a/docs/CODEBASE_AUDIT_REPORT.md
+++ b/docs/CODEBASE_AUDIT_REPORT.md
@@ -1,261 +1,150 @@
 # EconLife Codebase Audit Report
 
-**Date:** 2026-03-30
+**Original audit:** 2026-03-30
+**Last verified:** 2026-04-25
 **Scope:** Full simulation codebase (simulation/, packages/, CI, tests)
-**Codebase size:** 124 .cpp files, 116 .h files, 40+ modules, ~462 total files
 
 ---
 
 ## Executive Summary
 
-The codebase is well-structured for a bootstrap-phase project. Core architecture (tick orchestrator, DeltaBuffer, DeterministicRNG, cross-province propagation) is sound and matches the design specs. The module system is cleanly factored with consistent patterns. However, several issues were found ranging from determinism violations to memory safety concerns and architectural debt. This report categorizes findings by severity.
+The 2026-03-30 audit identified 3 critical, 6 high, 8 medium, and 8 low
+severity issues. As of 2026-04-25, 16 of 25 are resolved and 1 is
+partially resolved. The remaining 8 split into a perf concern (H5),
+two doc/lint issues (L1, L6), one data-integrity check (L5), one CI
+gap (L8), one architectural refactor (L3 — tracked separately as
+B1 in `docs/plans/2026-04-25-tier-b-followups.md`), and a cluster of
+stub `drain_deferred_work` handlers (M3) that wait on dependent modules.
+
+The architecture itself has held up well: the const-WorldState contract,
+DeltaBuffer pattern, and deterministic RNG have not needed to change.
+The original risks list ("concurrency untested", "memory management
+unsafe") is now obsolete — the threading is real, the lifetimes are
+managed by smart pointers, and CI actually runs all 1300+ tests.
 
 ---
 
-## CRITICAL Issues
-
-### C1. `const_cast` violates const WorldState contract in NpcBehaviorModule
-**File:** `simulation/modules/npc_behavior/npc_behavior_module.cpp:503`
-```cpp
-const_cast<WorldState&>(state).cross_province_delta_buffer.entries.push_back(cpd);
-```
-The ITickModule contract states modules receive `const WorldState&` and write only to `DeltaBuffer`. This `const_cast` mutates WorldState directly during province-parallel execution. If two provinces both have migrating NPCs, they will concurrently push to the same `entries` vector — a **data race** that causes undefined behavior and breaks determinism.
-
-**Impact:** Undefined behavior under concurrency; determinism violation.
-**Fix:** Province-parallel modules should write cross-province effects to a per-province buffer in the DeltaBuffer, then have the orchestrator merge them. Alternatively, add a `CrossProvinceDelta` vector to `DeltaBuffer` and merge in `apply_deltas`.
-
-### C2. Raw `new` allocations without corresponding `delete` — memory leaks
-**File:** `simulation/modules/persistence/persistence_module.cpp:1008,1652,1711`
-```cpp
-p.cohort_stats = new RegionCohortStats{};
-out_state.player = new PlayerCharacter(read_player(r));
-out_state.lod2_price_index = new GlobalCommodityPriceIndex{};
-```
-These use raw `new` with no `delete` path. `WorldState` has raw pointer members (`player`, `lod2_price_index`, `Province::cohort_stats`) that leak when WorldState is destroyed. The CLAUDE.md rule says "No raw pointers in module code — use smart pointers or pool allocation."
-
-**Impact:** Memory leaks on every world load/unload cycle.
-**Fix:** Change `PlayerCharacter*` to `std::unique_ptr<PlayerCharacter>`, `GlobalCommodityPriceIndex*` to `std::unique_ptr<GlobalCommodityPriceIndex>`, and `RegionCohortStats*` to `std::unique_ptr<RegionCohortStats>` (or use shared_ptr if needed for cross-references).
-
-### C3. `drain_deferred_work` directly mutates WorldState, bypassing DeltaBuffer
-**File:** `simulation/core/tick/drain_deferred_work.cpp:86-96,112-128,172-178`
-Handlers like `handle_npc_relationship_decay` and `handle_evidence_decay` directly modify NPC/evidence fields on `WorldState&` instead of writing to the `DeltaBuffer`. This violates the core architectural invariant: "WorldState is never modified mid-tick" (except via `apply_deltas`).
-
-```cpp
-// Direct mutation:
-rel.trust = std::max(0.0f, rel.trust - TRUST_DECAY_RATE);
-// And:
-token.actionability = std::max(0.0f, token.actionability - ...);
-npc->travel_status = NPCTravelStatus::resident;
-```
-
-**Impact:** Breaks the DeltaBuffer invariant; could cause modules that run later in the tick to see inconsistent state; undermines determinism guarantees.
-**Fix:** All handlers should write to the `DeltaBuffer& delta` parameter and let `apply_deltas` apply them.
-
----
-
-## HIGH Severity Issues
-
-### H1. NpcSpendingModule uses `home_province_id` instead of `current_province_id`
-**File:** `simulation/modules/npc_spending/npc_spending_module.cpp:106`
-```cpp
-if (npc.home_province_id == province.id && npc.status == NPCStatus::active) {
-```
-NpcBehaviorModule correctly uses `current_province_id` (line 213), but NpcSpendingModule filters by `home_province_id`. An NPC who has migrated or is visiting will spend in their home province rather than where they physically are. This breaks the physics principle (§18.14).
-
-**Impact:** Incorrect economic simulation for migrated/traveling NPCs.
-**Fix:** Change to `npc.current_province_id == province.id`.
-
-### H2. ProductionModule `initialized_` flag is not thread-safe
-**File:** `simulation/modules/production/production_module.cpp:86-88`
-```cpp
-if (!initialized_) {
-    init_from_world_state(state);
-    initialized_ = true;
-}
-```
-This lazy initialization runs inside `execute_province()`, which is a province-parallel method. If the orchestrator dispatches provinces to a thread pool, multiple threads could race on `initialized_`, causing double-initialization or seeing partially initialized registries.
-
-**Impact:** Data race on future thread pool activation; currently safe only because orchestrator runs provinces sequentially.
-**Fix:** Move initialization to a dedicated `init()` method called before the first tick, or use `std::call_once`.
-
-### H3. Evidence token ID generation uses `current_tick * 10000 + npc.id` — collision risk
-**File:** `simulation/modules/npc_behavior/npc_behavior_module.cpp:468`
-```cpp
-token.id = state.current_tick * 10000 + npc.id;
-```
-With 2000 NPCs and tick values >1000, this can overflow `uint32_t` and produce collisions. Also, multiple evidence-generating actions in the same tick from NPCs with ids differing by multiples of 10000 would collide.
-
-**Impact:** Evidence token ID collisions leading to incorrect evidence lookups.
-**Fix:** Use the auto-assignment path in `apply_evidence_deltas` (set `token.id = 0` and let `apply_deltas` assign the next available ID).
-
-### H4. ThreadPool is a stub — no actual parallelism
-**File:** `simulation/core/tick/thread_pool.h`
-The ThreadPool class is a no-op stub. The orchestrator's `execute_tick` method iterates provinces sequentially (line 164: `for (uint32_t p = 0; p < province_count; ++p)`). This means the province-parallel architecture is untested under actual concurrency.
-
-**Impact:** Province-parallel code may have latent data races that won't surface until real threading is enabled. The const_cast in C1 is proof of this.
-**Fix:** Implement ThreadPool with actual thread dispatch and run determinism tests under concurrency to flush out races. Even a 2-thread test would catch C1.
+## Open Issues
 
 ### H5. Linear scan lookups will exceed performance budget at scale
+
+**Status:** Open.
 **Files:** Multiple modules use O(N) linear scan for NPC/business lookups:
-- `apply_deltas.cpp:47`: `for (auto& n : world.significant_npcs)` per delta
-- `drain_deferred_work.cpp:31`: `find_npc` linear scan
-- `labor_market_module.cpp:565-572`: `find_employment` linear scan
-- `npc_spending_module.cpp:86-90`: `get_buyer_type` linear scan
 
-With 2000 NPCs and potentially thousands of deltas per tick, `apply_npc_deltas` alone is O(N*M) where N=NPCs and M=deltas. The 500ms tick budget at 2000 NPCs will be exceeded.
+- `simulation/core/world_state/apply_deltas.cpp:47` — per-NPCDelta scan over `world.significant_npcs`.
+- `simulation/core/tick/drain_deferred_work.cpp:26-32` — `find_npc` linear scan, called from every relationship/travel/evidence handler.
+- 22 occurrences of `for (const auto& npc : state.significant_npcs)` across modules (count via `grep -rc`).
+- 16 occurrences of `for (... : state.regional_markets)` across modules.
 
-**Impact:** Performance regression at V1 scale.
-**Fix:** Build hash maps (unordered_map<uint32_t, NPC*>) at tick start or maintain indexed lookups. Alternatively, ensure NPC vectors are sorted by ID and use binary search.
+With 2000 NPCs and thousands of deltas per tick, `apply_npc_deltas` is
+O(N·M). The 500ms tick budget at V1 scale will be exceeded.
 
-### H6. `apply_cross_province_deltas` silently drops future-tick entries
-**File:** `simulation/core/world_state/apply_deltas.cpp:476-477`
-```cpp
-if (entry.due_tick > world.current_tick)
-    continue;
-```
-After processing, `cpd.entries.clear()` (line 490) removes ALL entries, including those not yet due. Cross-province effects scheduled for future ticks (due_tick > current_tick) are lost.
+**Fix:** Build `std::unordered_map<uint32_t, size_t>` indices at tick
+start (or maintain them as the NPC vector is mutated) and route lookups
+through them. Alternative: sort NPCs by id and use `std::lower_bound`.
+Decide once a benchmark profile shows which paths dominate.
 
-**Impact:** Any cross-province effect scheduled more than 1 tick ahead is silently dropped.
-**Fix:** Partition entries: apply those that are due, retain those that aren't.
+**Priority:** This is the single largest remaining engineering risk. Do
+before tightening B3 (CI perf gate), otherwise the gate locks in a bad
+baseline.
 
----
+### M3. Many `drain_deferred_work` handlers are stubs
 
-## MEDIUM Severity Issues
+**Status:** Partial. 4 of 12 handlers fully implemented (relationship
+decay, evidence decay, NPC travel arrival, player travel arrival). The
+remaining 8 are intentional `(void)` no-ops awaiting their consuming
+modules:
 
-### M1. Kahn's algorithm topological sort is non-deterministic for equal-priority modules
-**File:** `simulation/core/tick/tick_orchestrator.cpp:87-107`
-When multiple modules have in_degree=0 simultaneously, `std::queue` processes them in insertion order, which depends on registration order in `register_base_game_modules.cpp`. This is deterministic as long as registration order doesn't change, but is fragile — adding a new module could change the execution order of existing modules with no explicit dependency.
+- `handle_consequence` — needs `ConsequenceEntry` definition (Session 16).
+- `handle_transit_arrival` — needs `TransitShipment` lookup table.
+- `handle_npc_business_decision` — Session 4+.
+- `handle_market_recompute` — design says this can stay a trigger no-op.
+- `handle_investigator_meter_update` — Session 15+.
+- `handle_climate_downstream` — pending real seasonal_agriculture.
+- `handle_community_stage_check` — Session 13.
+- `handle_maturation_advance`, `handle_commercialize` — pending R&D system.
+- `handle_interception_check` — Session 15+.
 
-**Fix:** Use a priority queue sorted by module name as a tiebreaker, documented as the canonical tie-breaking rule.
+**Fix:** No standalone fix; resolved as each consuming module lands.
+Track via the per-handler `// Will be implemented in...` comments.
 
-### M2. `NpcBehaviorModule` overwrites `capital_delta` for work/criminal actions
-**File:** `simulation/modules/npc_behavior/npc_behavior_module.cpp:389-403`
-```cpp
-if (best_cost > 0.0f) {
-    npc_delta.capital_delta = -best_cost;  // line 390
-}
-if (best_eval.action == DailyAction::work) {
-    float wage = 50.0f * employment_rate;
-    npc_delta.capital_delta = wage;  // overwrites the -best_cost!
-}
-```
-If an NPC's best action is `work` and it has `best_cost > 0`, the cost deduction is silently overwritten by the wage. Similarly, `criminal_activity` income overwrites any prior cost.
+### L1. `good_id_from_string` uses a weak hash
 
-**Fix:** Use additive logic: `npc_delta.capital_delta = (npc_delta.capital_delta.value_or(0.0f)) + wage;`
+**Status:** Open.
+**File:** `simulation/modules/production/production_module.cpp:68-75`.
 
-### M3. Many deferred work handlers are no-ops (stub implementations)
-**File:** `simulation/core/tick/drain_deferred_work.cpp`
-Handlers for: `consequence`, `transit_arrival`, `npc_business_decision`, `market_recompute`, `investigator_meter_update`, `climate_downstream`, `player_travel_arrival`, `community_stage_check`, `maturation_advance`, `commercialize`, `interception_check` are all no-ops.
+`hash * 31 + c` (Java string hash). Fine for the current ~252 goods, but
+string collisions are not bounded. If two recipe-referenced good ids
+collide, the bug surfaces as silently merged supply/demand on the wrong
+market — hard to diagnose.
 
-**Impact:** Items pushed to the deferred work queue for these types are silently consumed and do nothing. This is expected during bootstrap but should be tracked.
+**Fix:** Replace with FNV-1a or wyhash; or, better, change `good_id` to
+a stable integer assigned at goods-catalog load time and stored in a
+single source of truth, removing the per-call hash entirely.
 
-### M4. `demand_buffer` reset happens but `supply` is never decayed
-**File:** `simulation/core/tick/tick_orchestrator.cpp:141-143`
-The orchestrator resets `demand_buffer` to 0 each tick, but there's no equivalent decay for `supply`. Supply only changes via module deltas. If production modules produce supply but no module consumes it, supply accumulates without bound (until hitting `MARKET_SUPPLY_CEILING = 1e8`).
+### L3. Brittle delta merge in tick_orchestrator
 
-**Fix:** Consider adding natural supply decay (perishable goods) or ensure `npc_spending` consumption is sufficient to prevent unbounded accumulation.
+**Status:** Open. Tracked as **B1** in
+`docs/plans/2026-04-25-tier-b-followups.md`.
 
-### M5. Motivation delta in `apply_deltas` only modifies `weights[0]`
-**File:** `simulation/core/world_state/apply_deltas.cpp:119-130`
-The `motivation_delta` application adds the delta only to `weights[0]` (financial_gain), then renormalizes. But `NpcBehaviorModule` emits `motivation_diff` (total absolute difference across all weights) as the delta value. This means the actual motivation shift computed by the behavior module is not properly transferred — only a scalar "something changed" signal gets applied to a single slot.
+### L5. Goods CSV not cross-validated against recipe inputs/outputs
 
-**Impact:** NPC motivation shifts don't actually take effect as designed.
-**Fix:** Either pass the full MotivationVector as a replacement in NPCDelta, or add per-slot motivation deltas.
+**Status:** Open. No load-time check that every recipe `good_id` exists
+in the goods catalog. A typo in a recipe CSV produces a silently-zero
+production rate at runtime.
 
-### M6. No integration tests with actual modules registered
-**File:** `simulation/tests/determinism/determinism_test.cpp`
-All determinism tests run with `finalize_registration()` called on empty orchestrators (no modules). The 365-tick scale test only verifies orchestrator + state management. There are no tests that register actual modules and verify deterministic behavior end-to-end.
+**Fix:** In `recipe_catalog.cpp` (or a follow-up `validate_packages()`
+call after all catalogs load), iterate every recipe's inputs/outputs
+and assert each `good_id` exists in `GoodsCatalog`. Fail fast at
+package load.
 
-**Fix:** Add a determinism test that registers at least the Tier 1-3 modules (production, supply_chain, price_engine, labor_market) and verifies bit-identical state after N ticks.
+### L6. Tier comments in `register_base_game_modules.cpp` drift
 
-### M7. CI does not run scenario tests
-**File:** `.github/workflows/ci.yml:33-35`
-```yaml
-# Scenario tests are expected to FAIL during bootstrap.
-# Uncomment when module implementations are ready:
-# - name: Run scenario tests
-```
-42 modules are implemented, but scenario tests are still disabled.
+**Status:** Open. Cosmetic — topological sort handles the real order.
+The "Tier N: Depends on X" comments are a registration aid; some no
+longer match the dependency declarations the modules return from
+`runs_after()`. Either update the comments or generate them.
 
-### M8. WorldState destructor does not free raw pointer members
-**File:** `simulation/core/world_state/world_state.h`
-`WorldState` is a struct with no destructor. Members `player`, `lod2_price_index`, and `Province::cohort_stats` are raw pointers allocated with `new` in persistence. Without a destructor or smart pointers, these leak.
+### L8. No CI performance gate
+
+**Status:** Open. Tracked as **B3** in
+`docs/plans/2026-04-25-tier-b-followups.md`.
 
 ---
 
-## LOW Severity Issues
+## Resolved Issues
 
-### L1. `good_id_from_string` uses a weak hash function
-**File:** `simulation/modules/production/production_module.cpp:69-75`
-```cpp
-uint32_t hash = 0;
-for (char c : good_id_str) {
-    hash = hash * 31 + static_cast<uint32_t>(c);
-}
-```
-The hash `hash * 31 + c` is a classic Java string hash but has known collision rates. With ~60 goods currently this is fine, but could become problematic as the goods catalog grows.
-
-### L2. `CrossProvinceDeltaBuffer::push` is not thread-safe
-**File:** `simulation/core/world_state/cross_province_delta_buffer.cpp:10-12`
-The comment in `delta_buffer.h:152` says "Thread-safe via partitioning: each province worker appends to its own partition." But the actual implementation is a single vector with no partitioning. Currently safe only because the thread pool is a stub.
-
-### L3. Province delta merge in orchestrator is verbose and could miss new delta types
-**File:** `simulation/core/tick/tick_orchestrator.cpp:168-199`
-Each new DeltaBuffer field requires adding explicit merge code. If a developer adds a new delta vector to DeltaBuffer but forgets to update the merge loop, deltas are silently lost.
-
-**Fix:** Consider a `DeltaBuffer::merge_from(DeltaBuffer&& other)` method.
-
-### L4. `player_delta` not merged in province-parallel path
-**File:** `simulation/core/tick/tick_orchestrator.cpp:168-199`
-The province delta merge loop copies vectors but never merges `province_delta.player_delta` into `delta.player_delta`. If a province-parallel module writes player deltas, they are silently lost.
-
-### L5. No validation of goods CSV against recipe inputs/outputs
-The goods catalog (`goods_tier0.csv` through `goods_tier4.csv`) and recipes (`recipes_*.csv`) are loaded independently. There's no build-time or load-time validation that all recipe input/output `good_id` keys exist in the goods catalog.
-
-### L6. Some modules register Tier comments don't match `runs_after` chains
-In `register_base_game_modules.cpp`, comment "Tier 4: Depends on price engine" includes `FinancialDistributionModule`, but `FinancialDistributionModule`'s INTERFACE says it `runs_after: ["price_engine"]` — this is correct. However, it's registered before `NpcBusinessModule` which also says Tier 4 but has no explicit dependency between them. The topological sort handles this, but comment organization is misleading.
-
-### L7. Test world factory `create_test_player` casts `NPCTravelStatus` from literal
-**File:** `simulation/tests/test_world_factory.h:33`
-```cpp
-player.travel_status = static_cast<NPCTravelStatus>(0);  // resident
-```
-This relies on enum value mapping that could change. Should use the named enum value.
-
-### L8. Benchmark test exists but no performance gate in CI
-**File:** `.github/workflows/benchmark.yml` exists but benchmarks don't gate PR merges. The 500ms tick budget is a stated contract but is not enforced.
+| Item | Resolved by | Notes |
+|------|-------------|-------|
+| **C1** const_cast in npc_behavior | `b09a213` | Cross-province path now writes to `province_delta.cross_province_deltas`. |
+| **C2** raw `new` in persistence | `b09a213` | `PlayerCharacter`, `GlobalCommodityPriceIndex`, `RegionCohortStats` all `std::unique_ptr` (world_state.h:63,96; geography.h:678). |
+| **C3** drain mutates WorldState | `b09a213` (relationship/evidence/travel handlers); remaining stubs tracked under M3. |
+| **H1** home_province_id | `b09a213` | npc_spending_module.cpp:106 uses `current_province_id`. |
+| **H2** ProductionModule init race | `bdcdc0e` | `std::call_once` (production_module.cpp:86). |
+| **H3** evidence id collision (npc_id) | `b09a213` | `EvidenceModule::next_token_id_` counter. Antitrust had a separate collision; fixed in `32ae755` (Tier A). |
+| **H4** ThreadPool stub | `4a46185` | Real `submit`/`worker_loop`; orchestrator uses `parallel_for`. |
+| **H6** cross-province future-tick drop | `b09a213` | `apply_cross_province_deltas` partitions by `due_tick` (apply_deltas.cpp:594-615). |
+| **M1** topsort tiebreak | `a9b3660` | priority_queue ordered by module name. |
+| **M2** capital_delta overwrite | `b09a213` | Single accumulator (npc_behavior_module.cpp:391-410). |
+| **M4** supply decay missing | `4a46185` | `surplus_decay` applied each tick (tick_orchestrator.cpp:155-162). |
+| **M5** motivation_delta single-slot | `a9b3660` | `motivation_replacement` (full-vector) added to NPCDelta. `motivation_delta` retained for additive single-slot updates and explicitly documented. |
+| **M6** no integration determinism | `a9b3660` | determinism_test.cpp:282 and :311 register modules and verify bit-identical output. |
+| **M7** CI doesn't run scenario tests | `d8cc050` | Tier A: labels added to all four `catch_discover_tests` calls; CI now runs 1306 tests instead of 0. |
+| **M8** WorldState raw pointer leaks | `b09a213` | All three members migrated to `std::unique_ptr`. |
+| **L2** CrossProvinceDeltaBuffer thread safety | `a9b3660` | Pushes go through per-province DeltaBuffer; orchestrator merges into `world.cross_province_delta_buffer` from the main thread (apply_deltas.cpp:564). |
+| **L4** player_delta missed merge | (orchestrator refactor) | Merge added at tick_orchestrator.cpp:211-228. |
+| **L7** NPCTravelStatus literal cast | `32ae755` | Tier A. |
+| Supply chain transit-delay bypass | `32ae755` | Tier A. Was not in the original report but discovered during verification. |
 
 ---
 
-## Architecture Assessment
+## Recommended Priority Order (refreshed)
 
-### Strengths
-1. **Clean module interface** — `ITickModule` is well-designed with clear separation of province-parallel and sequential execution
-2. **DeltaBuffer pattern** — enforces the "read WorldState const, write deltas" rule effectively
-3. **Deterministic RNG** — SplitMix64 with fork() for province-parallel streams is correct and performant
-4. **Topological ordering** — Kahn's algorithm with cycle detection is robust
-5. **CI enforces key invariants** — dependency direction lint and forbidden randomness check
-6. **Good test coverage** — 40+ unit test files, determinism tests, scenario tests
-7. **Data-driven design** — CSV goods/recipes/facilities, JSON config — well separated from code
-8. **Comprehensive type system** — rich enums, well-documented structs with invariants
-
-### Risks
-1. **Concurrency untested** — All parallelism is stub; latent races exist (C1, H2, L2)
-2. **Performance at scale** — O(N) linear scans will fail at 2000 NPCs (H5)
-3. **Many stub handlers** — 11 of 15 deferred work handlers are no-ops (M3)
-4. **Memory management** — Raw pointers in WorldState need migration to smart pointers (C2, M8)
-
----
-
-## Recommended Priority Order
-
-1. **Fix C1** (const_cast data race) — architectural violation, blocks threading
-2. **Fix C3** (drain_deferred_work bypasses DeltaBuffer) — architectural violation
-3. **Fix H6** (cross-province deltas dropped) — silent data loss
-4. **Fix C2/M8** (raw pointers → smart pointers) — memory leaks
-5. **Fix H1** (home_province_id vs current_province_id) — simulation correctness
-6. **Fix M5** (motivation delta) — NPC behavior not working as designed
-7. **Fix M2** (capital_delta overwrite) — economic calculation error
-8. **Fix H3** (evidence token ID collision) — data integrity
-9. **Add integration determinism test** (M6) — validate end-to-end
-10. **Performance audit** (H5) — before scaling to 2000 NPCs
+1. **B2 — refresh this report** (this PR).
+2. **H5 — linear-scan lookups.** Largest perf risk; blocks meaningful CI perf gate.
+3. **B1 — `DeltaBuffer::merge_from`.** Mechanical refactor; pays for itself the next time someone adds a delta type.
+4. **L5 — recipe ↔ goods cross-validation.** Cheap, prevents silent typo bugs in modder content.
+5. **L1 — better good-id hash (or integer ids).** Lower risk than L5 today; revisit when goods catalog grows past a few hundred entries.
+6. **B3 — CI perf gate.** After H5; otherwise gate calibrates against known-slow code.
+7. **L6 — register-tier comments.** Cosmetic; do alongside any module-registration touch.
+8. **M3 stub handlers.** Resolve naturally as each consuming module lands.

--- a/docs/CODEBASE_AUDIT_REPORT.md
+++ b/docs/CODEBASE_AUDIT_REPORT.md
@@ -88,6 +88,16 @@ through ProductionModule / SupplyChainModule / SeasonalAgricultureModule
 and a small migration in their tests. Defer until the goods catalog
 grows past a few hundred entries or until a real collision surfaces.
 
+**Save-compat caveat.** Persistence serializes good_id values as
+uint32 (persistence_module.cpp:302, 633, 669, 941). Because the FNV-1a
+upgrade emits different uint32 values from the old `hash * 31 + c`,
+saves written by any pre-`62cf040` build will load successfully (the
+schema version did not change) but will hold IDs that no longer match
+runtime hashes — supply/demand will route to phantom markets. V1 is
+pre-release so this affects no real users, but the proper-fix migration
+to catalog numeric ids should bump CURRENT_SCHEMA_VERSION and reject
+incompatible saves explicitly.
+
 ### L3. Brittle delta merge in tick_orchestrator
 
 **Status:** Open. Tracked as **B1** in

--- a/docs/plans/2026-04-25-tier-b-followups.md
+++ b/docs/plans/2026-04-25-tier-b-followups.md
@@ -1,0 +1,169 @@
+# Tier B Follow-Ups — Architecture & Process Hygiene
+
+**Date:** 2026-04-25
+**Status:** Proposed
+**Origin:** Audit cleanup pass on `claude/setup-econlife-sim-367ph`. Tier A
+(supply_chain transit-delay bypass, antitrust evidence-id collision,
+test_world_factory enum cast) shipped in the same branch. The items below
+need design discussion before implementation.
+
+---
+
+## B1. `DeltaBuffer::merge_from` — eliminate brittle hand-merged province deltas
+
+### Problem
+`TickOrchestrator::execute_tick` (simulation/core/tick/tick_orchestrator.cpp,
+~lines 200-271) hand-merges every province-parallel `DeltaBuffer` field into
+the tick-level buffer:
+
+```cpp
+delta.npc_deltas.insert(...);
+delta.market_deltas.insert(...);
+delta.evidence_deltas.insert(...);
+// ...one block per vector...
+delta.cross_province_deltas.insert(...);
+```
+
+Plus per-field accumulator code for `player_delta` (additive for `health`,
+`wealth`, `exhaustion`; replacement for `skill`, `province`, etc.).
+
+This is two bugs waiting to happen:
+
+1. Adding a new delta type to `delta_buffer.h` requires the developer to
+   remember to add a merge clause here. Forget, and the deltas are silently
+   dropped — same shape as the L4 bug fixed earlier (player_delta merge missed
+   the province-parallel path until someone noticed).
+2. The replacement-vs-additive policy lives in two places: `apply_deltas.cpp`
+   and the orchestrator merge loop. Drift between them is not caught at
+   compile time.
+
+### Proposed approach
+1. Add `void DeltaBuffer::merge_from(DeltaBuffer&& other);` declared next to
+   the struct in `simulation/core/world_state/delta_buffer.h`. Implementation
+   in `delta_buffer.cpp` owns the entire merge policy.
+2. Replace the orchestrator's hand-rolled merge block with a single
+   `delta.merge_from(std::move(province_deltas[p]));`.
+3. For each `DeltaBuffer` member, document the policy with a short comment
+   at the field declaration (`// merge: append`, `// merge: additive sum`,
+   `// merge: last-write-wins`). This is the spec the merge implementation
+   reads.
+4. Add a static_assert or a unit test that constructs a populated
+   `DeltaBuffer`, merges it into another, and verifies every field flows
+   through. The test fails when a new field is added without merge support.
+
+### Risks / open questions
+- `player_delta`'s replacement fields (`new_province_id`, `skill_delta`)
+  currently use last-write-wins by province index ordering. That is
+  deterministic but arbitrary. Confirm it's the intended semantics, or
+  define explicit precedence (e.g. ascending `province_id`).
+- Performance: the existing merge is just `vector::insert`. `merge_from`
+  on a moved-from buffer should be no slower if it `std::move`s
+  vectors instead of copying.
+- Scope: keep this PR mechanical — no behavioral changes. Replacement of
+  the merge block + tests, nothing else.
+
+### Sizing
+~150 lines of code + tests. One PR.
+
+---
+
+## B2. Refresh `docs/CODEBASE_AUDIT_REPORT.md`
+
+### Problem
+The 2026-03-30 audit drove three weeks of fixes. Verification on
+2026-04-25 shows most items are now addressed but the report still lists
+them as open. New contributors reading the report will chase ghosts.
+
+Quick re-verification result:
+
+| Item | Status | Notes |
+|------|--------|-------|
+| C1 const_cast in npc_behavior | Fixed | No `const_cast<WorldState>` in npc_behavior_module.cpp; cross-province path uses `province_delta.cross_province_deltas`. |
+| C2 raw `new` in persistence | Fixed | No `= new` allocations remain in persistence_module.cpp. |
+| C3 drain mutates WorldState | Mostly fixed | `handle_npc_relationship_decay`, `handle_evidence_decay`, `handle_npc_travel_arrival`, `handle_player_travel_arrival` all write through DeltaBuffer. The remaining handlers (consequence, business_decision, climate_downstream, etc.) are stubbed pending dependent-module work. |
+| H1 home_province_id | Fixed | npc_spending_module.cpp:106 uses `current_province_id`. |
+| H2 ProductionModule init race | Fixed | Uses `std::call_once`. |
+| H3 evidence id collision (npc_id) | Fixed | EvidenceModule has `next_token_id_` counter. (Antitrust had a separate collision; fixed in Tier A.) |
+| H4 ThreadPool stub | Fixed | Real `submit`/`worker_loop` in thread_pool.cpp; orchestrator dispatches via `parallel_for`. |
+| H5 linear-scan lookups | Open | 22 NPC linear scans across modules; 16 regional_market scans. Real concern at 2k NPCs. |
+| H6 cross-province future-tick drop | Fixed | apply_deltas.cpp:594-615 partitions by `due_tick`. |
+| M1 topsort tiebreak | Fixed | priority_queue ordered by module name. |
+| M2 capital_delta overwrite | Fixed | Single accumulator in npc_behavior_module.cpp:391-410. |
+| M3 stub drain handlers | Partial | See C3 above. |
+| M4 supply decay missing | Fixed | tick_orchestrator.cpp:155-162 applies surplus_decay each tick. |
+| M5 motivation_delta single-slot | Mitigated | `motivation_replacement` (full-vector override) added to NPCDelta. |
+| M6 no integration determinism | Fixed | determinism_test.cpp:282 and :311 register modules. |
+| M7 CI doesn't run scenario tests | Fixed | Tier A: labels added; CI now runs all 1306 tests. |
+| M8 WorldState raw pointer leaks | Open | `player`, `lod2_price_index`, `Province::cohort_stats` still raw. |
+| L3 brittle delta merge | Open | Tracked here as B1. |
+| L4 player_delta missed merge | Fixed | tick_orchestrator.cpp:211-228. |
+| L7 NPCTravelStatus literal cast | Fixed | Tier A. |
+| L8 perf gate in CI | Open | benchmark.yml runs but doesn't gate. |
+
+### Proposed approach
+1. Move resolved entries to a "Resolved" section with the commit SHA that
+   addressed each.
+2. Re-state remaining open items (H5, M8 if still applicable, L1, L5, L6,
+   L8) with current line numbers.
+3. Re-evaluate priorities — the original "fix C1 first" ordering is no
+   longer relevant. H5 (perf at scale) and M8 (lifetimes) become the lead
+   items.
+
+### Sizing
+~30 minutes of edits. Doc-only PR.
+
+---
+
+## B3. CI performance gate
+
+### Problem
+The performance contract in `CLAUDE.md` is explicit: "Tick must complete
+in < 500ms at 2,000 significant NPCs. Target: < 200ms on 6 cores."
+Benchmarks exist (`simulation/tests/benchmarks/tick_benchmark.cpp`). A
+GitHub Actions workflow exists (`.github/workflows/benchmark.yml`).
+Neither gates merges — a 10x regression would pass CI silently, and we'd
+discover it during release prep.
+
+### Open questions (resolve before implementing)
+1. **Gate type.** Two viable shapes:
+   - *Absolute threshold.* Fail the build if `full tick performance at
+     2000 NPCs` exceeds, say, 600ms wall time. Simple, but flaky on
+     shared CI runners.
+   - *Relative regression.* Compare against a recorded baseline; fail if
+     >X% slower. Requires baseline storage (artifact, branch, S3).
+2. **Hardware variance.** GitHub Actions runners vary considerably tick
+   to tick. Either (a) run N iterations and use the median, (b) require
+   a self-hosted runner, or (c) gate only on `ubuntu-latest` Release with
+   a generous threshold.
+3. **What to gate.** The full-tick benchmark is the headline contract,
+   but `delta buffer merge`, `deferred work queue drain`, `RNG call`,
+   `persistence round-trip`, and `province parallel scaling` all have
+   targets too. Pick a small set or all.
+4. **Failure UX.** Should a regression block merge or just post a PR
+   comment? Blocking is right for the contract; commenting is right
+   while we tune the threshold.
+
+### Suggested first cut
+- Run the benchmark suite on `ubuntu-latest` Release in CI.
+- Parse the Catch2 benchmark JSON output.
+- Fail only on the full-tick benchmark, only if median > 750ms (1.5x the
+  contract, accounting for runner noise).
+- Post a comment on every PR with the benchmark numbers regardless of
+  pass/fail, so trend is visible.
+- Tighten the threshold once we have ~20 PRs of baseline data.
+
+### Sizing
+1-2 days. Needs runner-noise calibration before the threshold is
+meaningful. Defer until after H5 (linear-scan lookups) is addressed —
+otherwise the baseline is being set against known-slow code.
+
+---
+
+## Suggested ordering
+1. **B2 first** (~30 min). Cheap; unblocks correct prioritization of
+   everything else and stops new contributors from working off stale
+   info.
+2. **B1 next** (one focused PR). Pays for itself the next time someone
+   adds a delta type.
+3. **B3 last** (with H5 either before or alongside). Gating perf before
+   the known-slow lookup paths are addressed locks in a bad baseline.

--- a/simulation/core/CMakeLists.txt
+++ b/simulation/core/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(econlife_core STATIC
     tick/thread_pool.cpp
     tick/drain_deferred_work.cpp
     world_state/cross_province_delta_buffer.cpp
+    world_state/delta_buffer.cpp
     world_state/apply_deltas.cpp
     world_state/player_action_queue.cpp
     world_state/geography.cpp

--- a/simulation/core/good_id_hash.h
+++ b/simulation/core/good_id_hash.h
@@ -1,0 +1,38 @@
+#pragma once
+
+// Canonical good_id string -> uint32 hash.
+//
+// Used wherever a string good_id needs to be packed into a Recipe-derived
+// MarketDelta or NPCBusiness. Any code that compares MarketDelta.good_id
+// across modules MUST use this helper — divergent local hashes silently
+// route supply/demand to the wrong market.
+//
+// Implementation is FNV-1a (32-bit), chosen for:
+//   - Pure: same input -> same output, byte-identical across runs.
+//   - Defensible distribution: well-studied collision resistance for
+//     short ASCII keys at the V1 goods-catalog scale (~250 entries).
+//   - No allocation, branch-free hot loop.
+//
+// This is a transitional shim. The proper long-term fix is to look up
+// numeric ids from GoodsCatalog (which already assigns sequential ids
+// at load time), eliminating the per-call hash. That migration is
+// tracked separately — switching to catalog ids requires threading a
+// catalog reference through the modules that currently call this helper.
+
+#include <cstdint>
+#include <string_view>
+
+namespace econlife {
+
+inline uint32_t good_id_hash(std::string_view good_id) noexcept {
+    constexpr uint32_t FNV_OFFSET_BASIS = 0x811c9dc5u;
+    constexpr uint32_t FNV_PRIME = 0x01000193u;
+    uint32_t h = FNV_OFFSET_BASIS;
+    for (unsigned char c : good_id) {
+        h ^= c;
+        h *= FNV_PRIME;
+    }
+    return h;
+}
+
+}  // namespace econlife

--- a/simulation/core/tick/drain_deferred_work.cpp
+++ b/simulation/core/tick/drain_deferred_work.cpp
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <unordered_map>
 #include <vector>
 
 #include "core/world_state/apply_deltas.h"
@@ -21,14 +22,22 @@ namespace econlife {
 // Reschedule intervals and decay rates are passed via DrainConfig.
 
 // ---------------------------------------------------------------------------
-// Helper: find NPC by id
+// Helpers
 // ---------------------------------------------------------------------------
-static const NPC* find_npc(const WorldState& world, uint32_t npc_id) {
+using NPCIndex = std::unordered_map<uint32_t, const NPC*>;
+
+static const NPC* find_npc(const NPCIndex& index, uint32_t npc_id) {
+    auto it = index.find(npc_id);
+    return it == index.end() ? nullptr : it->second;
+}
+
+static NPCIndex build_npc_index(const WorldState& world) {
+    NPCIndex index;
+    index.reserve(world.significant_npcs.size());
     for (const auto& n : world.significant_npcs) {
-        if (n.id == npc_id)
-            return &n;
+        index[n.id] = &n;
     }
-    return nullptr;
+    return index;
 }
 
 // ---------------------------------------------------------------------------
@@ -64,7 +73,8 @@ static void handle_transit_arrival(const DeferredWorkItem& item, WorldState& wor
 }
 
 static void handle_npc_relationship_decay(const DeferredWorkItem& item, WorldState& world,
-                                          DeltaBuffer& delta, const DrainConfig& cfg) {
+                                          DeltaBuffer& delta, const DrainConfig& cfg,
+                                          const NPCIndex& npc_index) {
     // Batch decay for one NPC's relationships.
     // Trust and fear decay toward 0 over time.
     // Write relationship updates via DeltaBuffer (not direct mutation).
@@ -72,7 +82,7 @@ static void handle_npc_relationship_decay(const DeferredWorkItem& item, WorldSta
     if (!payload)
         return;
 
-    const NPC* npc = find_npc(world, payload->npc_id);
+    const NPC* npc = find_npc(npc_index, payload->npc_id);
     if (!npc)
         return;
 
@@ -191,10 +201,10 @@ static void handle_climate_downstream(const DeferredWorkItem& item, WorldState& 
 }
 
 static void handle_npc_travel_arrival(const DeferredWorkItem& item, WorldState& world,
-                                      DeltaBuffer& delta) {
+                                      DeltaBuffer& delta, const NPCIndex& npc_index) {
     // NPC physically arrives at destination province.
     // Write status change via DeltaBuffer (not direct mutation).
-    const NPC* npc = find_npc(world, item.subject_id);
+    const NPC* npc = find_npc(npc_index, item.subject_id);
     if (!npc)
         return;
 
@@ -272,6 +282,11 @@ static void handle_interception_check(const DeferredWorkItem& item, WorldState& 
 void drain_deferred_work(WorldState& world, DeltaBuffer& delta, const DrainConfig& cfg) {
     auto& queue = world.deferred_work_queue;
 
+    // Build the NPC lookup index once for the whole drain pass; the NPC vector
+    // is not mutated during the drain (mutations go through DeltaBuffer and
+    // apply_deltas runs after).
+    const NPCIndex npc_index = build_npc_index(world);
+
     while (!queue.empty() && queue.top().due_tick <= world.current_tick) {
         DeferredWorkItem item = queue.top();
         queue.pop();
@@ -287,7 +302,7 @@ void drain_deferred_work(WorldState& world, DeltaBuffer& delta, const DrainConfi
                 handle_interception_check(item, world, delta);
                 break;
             case WorkType::npc_relationship_decay:
-                handle_npc_relationship_decay(item, world, delta, cfg);
+                handle_npc_relationship_decay(item, world, delta, cfg, npc_index);
                 break;
             case WorkType::evidence_decay_batch:
                 handle_evidence_decay(item, world, delta, cfg);
@@ -309,7 +324,7 @@ void drain_deferred_work(WorldState& world, DeltaBuffer& delta, const DrainConfi
                 // For now, silently skip (no budget tracking yet).
                 break;
             case WorkType::npc_travel_arrival:
-                handle_npc_travel_arrival(item, world, delta);
+                handle_npc_travel_arrival(item, world, delta, npc_index);
                 break;
             case WorkType::player_travel_arrival:
                 handle_player_travel_arrival(item, world, delta);

--- a/simulation/core/tick/tick_orchestrator.cpp
+++ b/simulation/core/tick/tick_orchestrator.cpp
@@ -202,72 +202,10 @@ void TickOrchestrator::execute_tick(WorldState& state, ThreadPool& thread_pool) 
             });
 
             // Merge province deltas in ascending index order (deterministic).
+            // For PlayerDelta replacement fields this means highest province_id
+            // wins; vector deltas concatenate in ascending province order.
             for (uint32_t p = 0; p < province_count; ++p) {
-                auto& province_delta = province_deltas[p];
-                // Merge vector deltas into main delta buffer.
-                delta.npc_deltas.insert(delta.npc_deltas.end(), province_delta.npc_deltas.begin(),
-                                        province_delta.npc_deltas.end());
-                // Merge player_delta additively.
-                if (province_delta.player_delta.health_delta.has_value()) {
-                    delta.player_delta.health_delta =
-                        delta.player_delta.health_delta.value_or(0.0f) +
-                        *province_delta.player_delta.health_delta;
-                }
-                if (province_delta.player_delta.wealth_delta.has_value()) {
-                    delta.player_delta.wealth_delta =
-                        delta.player_delta.wealth_delta.value_or(0.0f) +
-                        *province_delta.player_delta.wealth_delta;
-                }
-                if (province_delta.player_delta.exhaustion_delta.has_value()) {
-                    delta.player_delta.exhaustion_delta =
-                        delta.player_delta.exhaustion_delta.value_or(0.0f) +
-                        *province_delta.player_delta.exhaustion_delta;
-                }
-                // Replacement fields: last province wins.
-                if (province_delta.player_delta.skill_delta.has_value()) {
-                    delta.player_delta.skill_delta = province_delta.player_delta.skill_delta;
-                }
-                if (province_delta.player_delta.new_evidence_awareness.has_value()) {
-                    delta.player_delta.new_evidence_awareness =
-                        province_delta.player_delta.new_evidence_awareness;
-                }
-                if (province_delta.player_delta.relationship_delta.has_value()) {
-                    delta.player_delta.relationship_delta =
-                        province_delta.player_delta.relationship_delta;
-                }
-                delta.market_deltas.insert(delta.market_deltas.end(),
-                                           province_delta.market_deltas.begin(),
-                                           province_delta.market_deltas.end());
-                delta.evidence_deltas.insert(delta.evidence_deltas.end(),
-                                             province_delta.evidence_deltas.begin(),
-                                             province_delta.evidence_deltas.end());
-                delta.consequence_deltas.insert(delta.consequence_deltas.end(),
-                                                province_delta.consequence_deltas.begin(),
-                                                province_delta.consequence_deltas.end());
-                delta.business_deltas.insert(delta.business_deltas.end(),
-                                             province_delta.business_deltas.begin(),
-                                             province_delta.business_deltas.end());
-                delta.region_deltas.insert(delta.region_deltas.end(),
-                                           province_delta.region_deltas.begin(),
-                                           province_delta.region_deltas.end());
-                delta.currency_deltas.insert(delta.currency_deltas.end(),
-                                             province_delta.currency_deltas.begin(),
-                                             province_delta.currency_deltas.end());
-                delta.technology_deltas.insert(delta.technology_deltas.end(),
-                                               province_delta.technology_deltas.begin(),
-                                               province_delta.technology_deltas.end());
-                delta.new_calendar_entries.insert(delta.new_calendar_entries.end(),
-                                                  province_delta.new_calendar_entries.begin(),
-                                                  province_delta.new_calendar_entries.end());
-                delta.new_scene_cards.insert(delta.new_scene_cards.end(),
-                                             province_delta.new_scene_cards.begin(),
-                                             province_delta.new_scene_cards.end());
-                delta.new_obligation_nodes.insert(delta.new_obligation_nodes.end(),
-                                                  province_delta.new_obligation_nodes.begin(),
-                                                  province_delta.new_obligation_nodes.end());
-                delta.cross_province_deltas.insert(delta.cross_province_deltas.end(),
-                                                    province_delta.cross_province_deltas.begin(),
-                                                    province_delta.cross_province_deltas.end());
+                delta.merge_from(std::move(province_deltas[p]));
             }
 
             // Apply province-parallel deltas before global post-pass so the

--- a/simulation/core/world_gen/recipe_catalog.cpp
+++ b/simulation/core/world_gen/recipe_catalog.cpp
@@ -8,6 +8,8 @@
 #include <fstream>
 #include <sstream>
 
+#include "core/world_gen/goods_catalog.h"
+
 namespace econlife {
 
 // ---------------------------------------------------------------------------
@@ -226,6 +228,25 @@ std::vector<const Recipe*> RecipeCatalog::recipes_available_at(uint8_t era) cons
         }
     }
     return result;
+}
+
+std::vector<std::string> RecipeCatalog::validate_against_goods(const GoodsCatalog& goods) const {
+    std::vector<std::string> errors;
+    for (const auto& recipe : recipes_) {
+        for (const auto& input : recipe.inputs) {
+            if (goods.find(input.good_id) == nullptr) {
+                errors.push_back("recipe '" + recipe.id + "' references unknown input good_id '" +
+                                 input.good_id + "'");
+            }
+        }
+        for (const auto& output : recipe.outputs) {
+            if (goods.find(output.good_id) == nullptr) {
+                errors.push_back("recipe '" + recipe.id + "' references unknown output good_id '" +
+                                 output.good_id + "'");
+            }
+        }
+    }
+    return errors;
 }
 
 }  // namespace econlife

--- a/simulation/core/world_gen/recipe_catalog.h
+++ b/simulation/core/world_gen/recipe_catalog.h
@@ -13,6 +13,8 @@
 
 namespace econlife {
 
+class GoodsCatalog;
+
 class RecipeCatalog {
    public:
     // Load all recipes_*.csv files from the given directory.
@@ -37,6 +39,13 @@ class RecipeCatalog {
 
     // Find all recipes available at a given era.
     std::vector<const Recipe*> recipes_available_at(uint8_t era) const;
+
+    // Verify every input/output good_id in every recipe exists in the goods
+    // catalog. Returns a list of error messages, one per missing reference.
+    // Empty vector means valid. Intended to be called once at world generation
+    // after both catalogs have loaded — a typo in a recipe CSV would
+    // otherwise surface only as a silently-zero supply delta at runtime.
+    std::vector<std::string> validate_against_goods(const GoodsCatalog& goods) const;
 
    private:
     std::vector<Recipe> recipes_;

--- a/simulation/core/world_gen/world_generator.cpp
+++ b/simulation/core/world_gen/world_generator.cpp
@@ -11,6 +11,7 @@
 #include <cmath>
 #include <cstdio>
 #include <fstream>
+#include <iostream>
 #include <nlohmann/json.hpp>
 #include <queue>
 #include <unordered_map>
@@ -264,6 +265,18 @@ WorldState WorldGenerator::generate(const WorldGeneratorConfig& config) {
     if (!config.facility_types_filepath.empty()) {
         facility_type_catalog.load_from_csv(config.facility_types_filepath);
     }
+
+    // Cross-validate recipe inputs/outputs against the goods catalog. A typo
+    // in a recipe CSV would otherwise silently zero out the corresponding
+    // supply or demand at runtime — surfaces here as a clear list at world
+    // generation. Logged to stderr so modders see it during package load.
+    if (recipe_catalog.size() > 0 && catalog.size() > 0) {
+        auto errors = recipe_catalog.validate_against_goods(catalog);
+        for (const auto& err : errors) {
+            std::cerr << "[recipe_catalog] " << err << "\n";
+        }
+    }
+
     if (recipe_catalog.size() > 0 && facility_type_catalog.size() > 0) {
         FacilityGenerator::create_facilities(world, rng, recipe_catalog, facility_type_catalog,
                                              config);

--- a/simulation/core/world_state/delta_buffer.cpp
+++ b/simulation/core/world_state/delta_buffer.cpp
@@ -1,0 +1,77 @@
+// DeltaBuffer / PlayerDelta merge implementations.
+// See delta_buffer.h for the per-field merge policy.
+
+#include "core/world_state/delta_buffer.h"
+
+#include <utility>
+
+namespace econlife {
+
+namespace {
+
+template <typename T>
+void move_extend(std::vector<T>& dst, std::vector<T>&& src) {
+    if (dst.empty()) {
+        dst = std::move(src);
+        return;
+    }
+    dst.reserve(dst.size() + src.size());
+    for (auto& item : src) {
+        dst.push_back(std::move(item));
+    }
+    src.clear();
+}
+
+}  // namespace
+
+void PlayerDelta::merge_from(PlayerDelta&& other) {
+    // Additive optionals: sum incoming into existing (or seed with incoming).
+    if (other.health_delta.has_value()) {
+        health_delta = health_delta.value_or(0.0f) + *other.health_delta;
+    }
+    if (other.wealth_delta.has_value()) {
+        wealth_delta = wealth_delta.value_or(0.0f) + *other.wealth_delta;
+    }
+    if (other.exhaustion_delta.has_value()) {
+        exhaustion_delta = exhaustion_delta.value_or(0.0f) + *other.exhaustion_delta;
+    }
+
+    // Replacement optionals: incoming wins when set.
+    if (other.skill_delta.has_value()) {
+        skill_delta = std::move(other.skill_delta);
+    }
+    if (other.new_evidence_awareness.has_value()) {
+        new_evidence_awareness = other.new_evidence_awareness;
+    }
+    if (other.relationship_delta.has_value()) {
+        relationship_delta = std::move(other.relationship_delta);
+    }
+    if (other.new_province_id.has_value()) {
+        new_province_id = other.new_province_id;
+    }
+    if (other.new_travel_status.has_value()) {
+        new_travel_status = other.new_travel_status;
+    }
+}
+
+void DeltaBuffer::merge_from(DeltaBuffer&& other) {
+    move_extend(npc_deltas, std::move(other.npc_deltas));
+    player_delta.merge_from(std::move(other.player_delta));
+    move_extend(market_deltas, std::move(other.market_deltas));
+    move_extend(evidence_deltas, std::move(other.evidence_deltas));
+    move_extend(consequence_deltas, std::move(other.consequence_deltas));
+    move_extend(business_deltas, std::move(other.business_deltas));
+    move_extend(region_deltas, std::move(other.region_deltas));
+    move_extend(currency_deltas, std::move(other.currency_deltas));
+    move_extend(technology_deltas, std::move(other.technology_deltas));
+    move_extend(new_calendar_entries, std::move(other.new_calendar_entries));
+    move_extend(new_scene_cards, std::move(other.new_scene_cards));
+    move_extend(new_obligation_nodes, std::move(other.new_obligation_nodes));
+    move_extend(cross_province_deltas, std::move(other.cross_province_deltas));
+    move_extend(dissolved_businesses, std::move(other.dissolved_businesses));
+    move_extend(new_businesses, std::move(other.new_businesses));
+    move_extend(scene_card_choice_deltas, std::move(other.scene_card_choice_deltas));
+    move_extend(calendar_commit_deltas, std::move(other.calendar_commit_deltas));
+}
+
+}  // namespace econlife

--- a/simulation/core/world_state/delta_buffer.h
+++ b/simulation/core/world_state/delta_buffer.h
@@ -46,12 +46,18 @@ struct NPCDelta {
 struct PlayerDelta {
     std::optional<float> health_delta;                    // additive
     std::optional<float> wealth_delta;                    // additive; liquid cash only
-    std::optional<SkillDelta> skill_delta;                // skill_id + additive value
-    std::optional<uint32_t> new_evidence_awareness;       // evidence token id
+    std::optional<SkillDelta> skill_delta;                // replacement; latest skill update wins
+    std::optional<uint32_t> new_evidence_awareness;       // replacement; latest evidence token wins
     std::optional<float> exhaustion_delta;                // additive
-    std::optional<RelationshipDelta> relationship_delta;  // player <-> NPC update
+    std::optional<RelationshipDelta> relationship_delta;  // replacement; latest update wins
     std::optional<uint32_t> new_province_id;              // replacement; player location
     std::optional<NPCTravelStatus> new_travel_status;     // replacement; travel state
+
+    // Merge another PlayerDelta into this one.
+    // Additive fields sum; replacement fields take the incoming value when set.
+    // Used by DeltaBuffer::merge_from when collapsing per-province deltas in
+    // ascending province order, so "last write wins" means highest province_id.
+    void merge_from(PlayerDelta&& other);
 };
 
 struct MarketDelta {
@@ -164,6 +170,18 @@ struct CalendarCommitDelta {
 
 // Accumulated state changes for one tick step.
 // Pre-reserve vectors at WorldState initialization using known NPC count.
+//
+// Merge policy (see merge_from below):
+// - Every vector field appends (move-extend) — entries from `other` are
+//   moved onto the end of the corresponding vector here.
+// - `player_delta` merges through PlayerDelta::merge_from (additive +
+//   last-write-wins per field).
+//
+// IMPORTANT: When you add a new field to DeltaBuffer, you MUST update
+// merge_from in delta_buffer.cpp, or per-province writes to the new
+// field will be silently dropped during the orchestrator's province
+// merge. The test_delta_buffer_merge_covers_every_field unit test will
+// fail when a new field is added without corresponding merge support.
 struct DeltaBuffer {
     std::vector<NPCDelta> npc_deltas;
     PlayerDelta player_delta;
@@ -182,6 +200,11 @@ struct DeltaBuffer {
     std::vector<NewBusinessDelta> new_businesses;
     std::vector<SceneCardChoiceDelta> scene_card_choice_deltas;
     std::vector<CalendarCommitDelta> calendar_commit_deltas;
+
+    // Merge another DeltaBuffer into this one. Vectors are move-extended;
+    // player_delta merges through PlayerDelta::merge_from. After the call
+    // `other` is in a valid but unspecified (moved-from) state.
+    void merge_from(DeltaBuffer&& other);
 };
 
 // Cross-province effects are accumulated here during apply_deltas (main thread only).

--- a/simulation/modules/antitrust/antitrust_module.cpp
+++ b/simulation/modules/antitrust/antitrust_module.cpp
@@ -166,9 +166,7 @@ void AntitrustModule::run_monthly_check(const WorldState& state, DeltaBuffer& de
 
             EvidenceDelta hhi_ev;
             EvidenceToken hhi_token;
-            // Synthetic id: encode province + good to avoid collision across markets.
-            hhi_token.id =
-                (state.current_tick * 10000) + (mk.province_id * 100) + (mk.good_id % 100);
+            hhi_token.id = next_evidence_token_id_++;
             hhi_token.type = EvidenceType::financial;
             hhi_token.source_npc_id = 0;  // public market data
             hhi_token.target_npc_id = 0;  // market-level, not actor-specific

--- a/simulation/modules/antitrust/antitrust_module.h
+++ b/simulation/modules/antitrust/antitrust_module.h
@@ -88,6 +88,10 @@ class AntitrustModule : public ITickModule {
     uint32_t next_check_tick_ = 30;
     std::vector<AntitrustProposal> proposals_;
     uint32_t next_proposal_id_ = 1000;
+    // Antitrust-issued evidence token ids start above EvidenceModule's
+    // counter range (which begins at 1000) and any reasonable evidence
+    // pool size, so the two id streams cannot collide.
+    uint32_t next_evidence_token_id_ = 1'000'000;
 
     // Run the monthly antitrust scan.
     void run_monthly_check(const WorldState& state, DeltaBuffer& delta);

--- a/simulation/modules/labor_market/labor_market_module.cpp
+++ b/simulation/modules/labor_market/labor_market_module.cpp
@@ -23,19 +23,25 @@ void LaborMarketModule::init_for_tick(const WorldState& state) {
     // dispatch, so no synchronisation is needed.  After this call the vector's
     // size is stable and execute_province() never pushes new elements — it only
     // mutates fields of records that belong to NPCs in its own province.
+    //
+    // Maintain employment_index_ inline: rebuild once if it is out of sync
+    // (e.g. tests appended directly through the employment_records() accessor),
+    // then update it as we push new records so the per-NPC find is O(1).
+    if (employment_index_.size() != employment_records_.size()) {
+        rebuild_employment_index();
+    }
+    auto ensure_record = [&](uint32_t npc_id) {
+        if (employment_index_.find(npc_id) != employment_index_.end()) return;
+        employment_index_[npc_id] = employment_records_.size();
+        employment_records_.push_back(EmploymentRecord{npc_id, /*employer_business_id=*/0,
+                                                       /*offered_wage=*/0.0f, /*hired_tick=*/0,
+                                                       /*deferred_salary_ticks=*/0});
+    };
     for (const auto& npc : state.significant_npcs) {
-        if (find_employment(npc.id) == nullptr) {
-            employment_records_.push_back(
-                EmploymentRecord{npc.id, /*employer_business_id=*/0,
-                                 /*offered_wage=*/0.0f, /*hired_tick=*/0, /*deferred_salary_ticks=*/0});
-        }
+        ensure_record(npc.id);
     }
     for (const auto& npc : state.named_background_npcs) {
-        if (find_employment(npc.id) == nullptr) {
-            employment_records_.push_back(
-                EmploymentRecord{npc.id, /*employer_business_id=*/0,
-                                 /*offered_wage=*/0.0f, /*hired_tick=*/0, /*deferred_salary_ticks=*/0});
-        }
+        ensure_record(npc.id);
     }
 }
 
@@ -583,22 +589,30 @@ float LaborMarketModule::compute_salary_expectation(float regional_wage, float m
 // LaborMarketModule — lookup helpers
 // ===========================================================================
 
-EmploymentRecord* LaborMarketModule::find_employment(uint32_t npc_id) {
-    for (auto& rec : employment_records_) {
-        if (rec.npc_id == npc_id) {
-            return &rec;
-        }
+void LaborMarketModule::rebuild_employment_index() const {
+    employment_index_.clear();
+    employment_index_.reserve(employment_records_.size());
+    for (std::size_t i = 0; i < employment_records_.size(); ++i) {
+        employment_index_[employment_records_[i].npc_id] = i;
     }
-    return nullptr;
+}
+
+EmploymentRecord* LaborMarketModule::find_employment(uint32_t npc_id) {
+    if (employment_index_.size() != employment_records_.size()) {
+        rebuild_employment_index();
+    }
+    auto it = employment_index_.find(npc_id);
+    if (it == employment_index_.end()) return nullptr;
+    return &employment_records_[it->second];
 }
 
 const EmploymentRecord* LaborMarketModule::find_employment(uint32_t npc_id) const {
-    for (const auto& rec : employment_records_) {
-        if (rec.npc_id == npc_id) {
-            return &rec;
-        }
+    if (employment_index_.size() != employment_records_.size()) {
+        rebuild_employment_index();
     }
-    return nullptr;
+    auto it = employment_index_.find(npc_id);
+    if (it == employment_index_.end()) return nullptr;
+    return &employment_records_[it->second];
 }
 
 const NPC* LaborMarketModule::find_npc(const WorldState& state, uint32_t npc_id) {

--- a/simulation/modules/labor_market/labor_market_module.cpp
+++ b/simulation/modules/labor_market/labor_market_module.cpp
@@ -31,7 +31,8 @@ void LaborMarketModule::init_for_tick(const WorldState& state) {
         rebuild_employment_index();
     }
     auto ensure_record = [&](uint32_t npc_id) {
-        if (employment_index_.find(npc_id) != employment_index_.end()) return;
+        if (employment_index_.find(npc_id) != employment_index_.end())
+            return;
         employment_index_[npc_id] = employment_records_.size();
         employment_records_.push_back(EmploymentRecord{npc_id, /*employer_business_id=*/0,
                                                        /*offered_wage=*/0.0f, /*hired_tick=*/0,
@@ -602,7 +603,8 @@ EmploymentRecord* LaborMarketModule::find_employment(uint32_t npc_id) {
         rebuild_employment_index();
     }
     auto it = employment_index_.find(npc_id);
-    if (it == employment_index_.end()) return nullptr;
+    if (it == employment_index_.end())
+        return nullptr;
     return &employment_records_[it->second];
 }
 
@@ -611,7 +613,8 @@ const EmploymentRecord* LaborMarketModule::find_employment(uint32_t npc_id) cons
         rebuild_employment_index();
     }
     auto it = employment_index_.find(npc_id);
-    if (it == employment_index_.end()) return nullptr;
+    if (it == employment_index_.end())
+        return nullptr;
     return &employment_records_[it->second];
 }
 

--- a/simulation/modules/labor_market/labor_market_module.h
+++ b/simulation/modules/labor_market/labor_market_module.h
@@ -104,9 +104,17 @@ class LaborMarketModule : public ITickModule {
     LaborModuleConfig lcfg_;
     std::vector<JobPosting> job_postings_;
     std::vector<EmploymentRecord> employment_records_;
+    // npc_id -> index into employment_records_. Rebuilt lazily when its
+    // size diverges from employment_records_ (covers both internal pushes
+    // and external pushes via the employment_records() accessor used by
+    // tests). Mutable so const find_employment can refresh on demand.
+    mutable std::unordered_map<uint32_t, std::size_t> employment_index_;
     std::unordered_map<uint32_t, std::vector<NPCSkillEntry>> npc_skills_;
     RegionalWageMap regional_wages_;
     std::unordered_map<uint32_t, std::vector<WorkerApplication>> applications_;
+
+    // Rebuild employment_index_ from employment_records_. Idempotent.
+    void rebuild_employment_index() const;
 
     // --- Per-province processing ---
 

--- a/simulation/modules/npc_spending/npc_spending_module.cpp
+++ b/simulation/modules/npc_spending/npc_spending_module.cpp
@@ -83,11 +83,18 @@ float NpcSpendingModule::buyer_type_quality_weight(BuyerType buyer_type) {
 // ---------------------------------------------------------------------------
 
 BuyerType NpcSpendingModule::get_buyer_type(uint32_t npc_id) const {
-    for (const auto& profile : buyer_profiles_) {
-        if (profile.npc_id == npc_id)
-            return profile.buyer_type;
+    if (buyer_profile_index_.size() != buyer_profiles_.size()) {
+        buyer_profile_index_.clear();
+        buyer_profile_index_.reserve(buyer_profiles_.size());
+        for (std::size_t i = 0; i < buyer_profiles_.size(); ++i) {
+            buyer_profile_index_[buyer_profiles_[i].npc_id] = i;
+        }
     }
-    return BuyerType::necessity_buyer;  // default
+    auto it = buyer_profile_index_.find(npc_id);
+    if (it == buyer_profile_index_.end()) {
+        return BuyerType::necessity_buyer;  // default
+    }
+    return buyer_profiles_[it->second].buyer_type;
 }
 
 // ---------------------------------------------------------------------------

--- a/simulation/modules/npc_spending/npc_spending_module.h
+++ b/simulation/modules/npc_spending/npc_spending_module.h
@@ -9,6 +9,7 @@
 
 #include <cstdint>
 #include <string_view>
+#include <unordered_map>
 #include <vector>
 
 #include "core/config/package_config.h"
@@ -84,6 +85,10 @@ class NpcSpendingModule : public ITickModule {
    private:
     NpcSpendingConfig cfg_;
     std::vector<NPCBuyerProfile> buyer_profiles_;
+    // npc_id -> index into buyer_profiles_. Rebuilt lazily when its size
+    // diverges from buyer_profiles_, so external pushes through the
+    // accessor stay supported. Mutable so const get_buyer_type can refresh.
+    mutable std::unordered_map<uint32_t, std::size_t> buyer_profile_index_;
 
     // Find buyer type for an NPC. Returns necessity_buyer if no profile found.
     BuyerType get_buyer_type(uint32_t npc_id) const;

--- a/simulation/modules/production/production_module.cpp
+++ b/simulation/modules/production/production_module.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <cmath>
 
+#include "core/good_id_hash.h"
 #include "core/rng/deterministic_rng.h"
 #include "core/world_state/delta_buffer.h"
 #include "core/world_state/world_state.h"
@@ -66,13 +67,7 @@ void ProductionModule::init_from_world_state(const WorldState& state) {
 // ===========================================================================
 
 uint32_t ProductionModule::good_id_from_string(const std::string& good_id_str) {
-    // Deterministic hash for V1 prototype.
-    // The goods registry will provide the canonical mapping in full implementation.
-    uint32_t hash = 0;
-    for (char c : good_id_str) {
-        hash = hash * 31 + static_cast<uint32_t>(c);
-    }
-    return hash;
+    return good_id_hash(good_id_str);
 }
 
 // ===========================================================================

--- a/simulation/modules/register_base_game_modules.cpp
+++ b/simulation/modules/register_base_game_modules.cpp
@@ -4,85 +4,83 @@
 
 #include "core/tick/tick_orchestrator.h"
 
-// Core: Player action processing (runs before all domain modules)
+// Section grouping below is by module domain, not dependency tier.
+// Execution order is decided by each module's runs_after()/runs_before()
+// declarations and resolved by TickOrchestrator's topological sort —
+// the registration order here only matters as a tiebreaker (see M1
+// in docs/CODEBASE_AUDIT_REPORT.md).
+
+// Player input
 #include "modules/player_actions/player_actions_module.h"
 
-// Tier 1: No inter-module dependencies
+// Production, markets, and trade
 #include "modules/business_lifecycle/business_lifecycle_module.h"
-#include "modules/calendar/calendar_module.h"
+#include "modules/commodity_trading/commodity_trading_module.h"
+#include "modules/labor_market/labor_market_module.h"
+#include "modules/npc_business/npc_business_module.h"
+#include "modules/price_engine/price_engine_module.h"
 #include "modules/production/production_module.h"
+#include "modules/real_estate/real_estate_module.h"
+#include "modules/seasonal_agriculture/seasonal_agriculture_module.h"
+#include "modules/supply_chain/supply_chain_module.h"
+#include "modules/trade_infrastructure/trade_infrastructure_module.h"
+
+// Finance, government, and population
+#include "modules/banking/banking_module.h"
+#include "modules/currency_exchange/currency_exchange_module.h"
+#include "modules/financial_distribution/financial_distribution_module.h"
+#include "modules/government_budget/government_budget_module.h"
+#include "modules/healthcare/healthcare_module.h"
+#include "modules/population_aging/population_aging_module.h"
+
+// Calendar, scenes, technology, and random events
+#include "modules/calendar/calendar_module.h"
 #include "modules/random_events/random_events_module.h"
 #include "modules/scene_cards/scene_cards_module.h"
 #include "modules/technology/technology_module.h"
 
-// Tier 2: Depends on production
-#include "modules/labor_market/labor_market_module.h"
-#include "modules/seasonal_agriculture/seasonal_agriculture_module.h"
-#include "modules/supply_chain/supply_chain_module.h"
-
-// Tier 3: Depends on supply chain
-#include "modules/price_engine/price_engine_module.h"
-#include "modules/trade_infrastructure/trade_infrastructure_module.h"
-
-// Tier 4: Depends on price engine
-#include "modules/commodity_trading/commodity_trading_module.h"
-#include "modules/financial_distribution/financial_distribution_module.h"
-#include "modules/npc_business/npc_business_module.h"
-#include "modules/real_estate/real_estate_module.h"
-
-// Tier 5: Depends on financial distribution
-#include "modules/banking/banking_module.h"
-#include "modules/government_budget/government_budget_module.h"
-#include "modules/healthcare/healthcare_module.h"
+// NPC behaviour, spending, relationships
 #include "modules/npc_behavior/npc_behavior_module.h"
-
-// Tier 6: Depends on NPC behavior
-#include "modules/community_response/community_response_module.h"
-#include "modules/evidence/evidence_module.h"
 #include "modules/npc_spending/npc_spending_module.h"
 #include "modules/obligation_network/obligation_network_module.h"
+#include "modules/trust_updates/trust_updates_module.h"
 
-// Tier 7: Depends on evidence
+// Community, political, and regional dynamics
+#include "modules/community_response/community_response_module.h"
+#include "modules/influence_network/influence_network_module.h"
+#include "modules/political_cycle/political_cycle_module.h"
+#include "modules/regional_conditions/regional_conditions_module.h"
+
+// Evidence, investigation, antitrust, and media
 #include "modules/antitrust/antitrust_module.h"
-#include "modules/criminal_operations/criminal_operations_module.h"
+#include "modules/evidence/evidence_module.h"
 #include "modules/facility_signals/facility_signals_module.h"
+#include "modules/investigator_engine/investigator_engine_module.h"
+#include "modules/legal_process/legal_process_module.h"
 #include "modules/media_system/media_system_module.h"
 
-// Tier 8: Depends on criminal operations
+// Criminal economy
+#include "modules/addiction/addiction_module.h"
+#include "modules/alternative_identity/alternative_identity_module.h"
+#include "modules/criminal_operations/criminal_operations_module.h"
+#include "modules/designer_drug/designer_drug_module.h"
 #include "modules/drug_economy/drug_economy_module.h"
-#include "modules/investigator_engine/investigator_engine_module.h"
+#include "modules/informant_system/informant_system_module.h"
 #include "modules/money_laundering/money_laundering_module.h"
 #include "modules/protection_rackets/protection_rackets_module.h"
 #include "modules/weapons_trafficking/weapons_trafficking_module.h"
 
-// Tier 9: Depends on investigator engine
-#include "modules/alternative_identity/alternative_identity_module.h"
-#include "modules/designer_drug/designer_drug_module.h"
-#include "modules/informant_system/informant_system_module.h"
-#include "modules/legal_process/legal_process_module.h"
-
-// Tier 10: Depends on community response
-#include "modules/addiction/addiction_module.h"
-#include "modules/influence_network/influence_network_module.h"
-#include "modules/political_cycle/political_cycle_module.h"
-#include "modules/trust_updates/trust_updates_module.h"
-
-// Tier 11: Mixed dependencies
-#include "modules/currency_exchange/currency_exchange_module.h"
+// Infrastructure: LOD and persistence
 #include "modules/lod_system/lod_system_module.h"
-#include "modules/population_aging/population_aging_module.h"
-#include "modules/regional_conditions/regional_conditions_module.h"
-
-// Tier 12: Persistence
 #include "modules/persistence/persistence_module.h"
 
 namespace econlife {
 
 void register_base_game_modules(TickOrchestrator& orchestrator, const PackageConfig& config) {
-    // Core: Player actions
+    // Player input
     orchestrator.register_module(std::make_unique<PlayerActionsModule>());
 
-    // Tier 1
+    // Production, markets, and trade
     orchestrator.register_module(std::make_unique<CalendarModule>());
     orchestrator.register_module(std::make_unique<TechnologyModule>(config.rnd));
     orchestrator.register_module(
@@ -90,20 +88,14 @@ void register_base_game_modules(TickOrchestrator& orchestrator, const PackageCon
     orchestrator.register_module(std::make_unique<ProductionModule>(config.production));
     orchestrator.register_module(std::make_unique<SceneCardsModule>(config.scene_cards));
     orchestrator.register_module(std::make_unique<RandomEventsModule>(config.random_events));
-
-    // Tier 2
     orchestrator.register_module(std::make_unique<SupplyChainModule>(config.supply_chain_module));
     orchestrator.register_module(std::make_unique<LaborMarketModule>(config.labor_module));
     orchestrator.register_module(
         std::make_unique<SeasonalAgricultureModule>(config.seasonal_agriculture));
-
-    // Tier 3
     orchestrator.register_module(
         std::make_unique<PriceEngineModule>(config.price_model, config.price_engine));
     orchestrator.register_module(
         std::make_unique<TradeInfrastructureModule>(config.trade_infrastructure));
-
-    // Tier 4
     orchestrator.register_module(
         std::make_unique<FinancialDistributionModule>(config.financial_distribution));
     orchestrator.register_module(std::make_unique<NpcBusinessModule>(config.npc_business));
@@ -111,7 +103,7 @@ void register_base_game_modules(TickOrchestrator& orchestrator, const PackageCon
         std::make_unique<CommodityTradingModule>(config.commodity_trading));
     orchestrator.register_module(std::make_unique<RealEstateModule>(config.real_estate));
 
-    // Tier 5
+    // Finance, government, and population
     orchestrator.register_module(
         std::make_unique<NpcBehaviorModule>(config.npc_behavior_module, config.npc_behavior));
     orchestrator.register_module(std::make_unique<BankingModule>(config.banking));
@@ -119,7 +111,7 @@ void register_base_game_modules(TickOrchestrator& orchestrator, const PackageCon
         std::make_unique<GovernmentBudgetModule>(config.government_budget));
     orchestrator.register_module(std::make_unique<HealthcareModule>(config.healthcare));
 
-    // Tier 6
+    // NPC behaviour, spending, relationships
     orchestrator.register_module(std::make_unique<NpcSpendingModule>(config.npc_spending));
     orchestrator.register_module(std::make_unique<EvidenceModule>(config.evidence));
     orchestrator.register_module(
@@ -127,14 +119,14 @@ void register_base_game_modules(TickOrchestrator& orchestrator, const PackageCon
     orchestrator.register_module(
         std::make_unique<CommunityResponseModule>(config.community_response));
 
-    // Tier 7
+    // Evidence, investigation, antitrust, and media
     orchestrator.register_module(std::make_unique<FacilitySignalsModule>(config.facility_signals));
     orchestrator.register_module(
         std::make_unique<CriminalOperationsModule>(config.criminal_operations));
     orchestrator.register_module(std::make_unique<MediaSystemModule>(config.media_system));
     orchestrator.register_module(std::make_unique<AntitrustModule>(config.antitrust));
 
-    // Tier 8
+    // Criminal economy
     orchestrator.register_module(
         std::make_unique<InvestigatorEngineModule>(config.investigator_engine));
     orchestrator.register_module(std::make_unique<MoneyLaunderingModule>(config.money_laundering));
@@ -143,30 +135,26 @@ void register_base_game_modules(TickOrchestrator& orchestrator, const PackageCon
         std::make_unique<WeaponsTraffickingModule>(config.weapons_trafficking));
     orchestrator.register_module(
         std::make_unique<ProtectionRacketsModule>(config.protection_rackets));
-
-    // Tier 9
     orchestrator.register_module(std::make_unique<LegalProcessModule>(config.legal_process));
     orchestrator.register_module(std::make_unique<InformantSystemModule>(config.informant));
     orchestrator.register_module(
         std::make_unique<AlternativeIdentityModule>(config.alternative_identity));
     orchestrator.register_module(std::make_unique<DesignerDrugModule>(config.designer_drug));
 
-    // Tier 10
+    // Community, political, and regional dynamics
     orchestrator.register_module(std::make_unique<PoliticalCycleModule>(config.political_cycle));
     orchestrator.register_module(
         std::make_unique<InfluenceNetworkModule>(config.influence_network));
     orchestrator.register_module(std::make_unique<TrustUpdatesModule>(config.trust_updates));
     orchestrator.register_module(std::make_unique<AddictionModule>(config.addiction));
-
-    // Tier 11
     orchestrator.register_module(
         std::make_unique<RegionalConditionsModule>(config.regional_conditions));
     orchestrator.register_module(std::make_unique<PopulationAgingModule>(config.population_aging));
     orchestrator.register_module(
         std::make_unique<CurrencyExchangeModule>(config.currency_exchange));
-    orchestrator.register_module(std::make_unique<LodSystemModule>(config.lod_system));
 
-    // Tier 12
+    // Infrastructure: LOD and persistence
+    orchestrator.register_module(std::make_unique<LodSystemModule>(config.lod_system));
     orchestrator.register_module(std::make_unique<PersistenceModule>());
 }
 

--- a/simulation/modules/seasonal_agriculture/seasonal_agriculture_module.cpp
+++ b/simulation/modules/seasonal_agriculture/seasonal_agriculture_module.cpp
@@ -14,6 +14,7 @@
 #include <algorithm>
 #include <cmath>
 
+#include "core/good_id_hash.h"
 #include "core/world_state/delta_buffer.h"
 #include "core/world_state/world_state.h"
 
@@ -31,12 +32,7 @@ namespace econlife {
 // ===========================================================================
 
 uint32_t SeasonalAgricultureModule::good_id_from_string(const std::string& good_id_str) {
-    // Same deterministic hash as ProductionModule for V1 prototype consistency.
-    uint32_t hash = 0;
-    for (char c : good_id_str) {
-        hash = hash * 31 + static_cast<uint32_t>(c);
-    }
-    return hash;
+    return good_id_hash(good_id_str);
 }
 
 bool SeasonalAgricultureModule::is_annual_cycle(CropCategory category) {

--- a/simulation/modules/supply_chain/supply_chain_module.cpp
+++ b/simulation/modules/supply_chain/supply_chain_module.cpp
@@ -288,9 +288,11 @@ void SupplyChainModule::dispatch_inter_province(uint32_t province_id, const Worl
             arrival_item.subject_id = shipment_id;
             arrival_item.payload = TransitPayload{shipment_id, province_id};
 
-            // Push to cross-province delta buffer for one-tick delay semantics.
-            // The market supply at the destination will increase when the
-            // shipment arrives.
+            // Push to cross-province delta buffer for transit-delay semantics.
+            // The market supply at the destination increases when the shipment
+            // arrives at due_tick. The orchestrator merges province deltas into
+            // WorldState.cross_province_delta_buffer; apply_cross_province_deltas
+            // releases entries on the tick that matches due_tick.
             CrossProvinceDelta cpd{};
             cpd.source_province_id = src;
             cpd.target_province_id = province_id;
@@ -302,15 +304,7 @@ void SupplyChainModule::dispatch_inter_province(uint32_t province_id, const Worl
             arrival_market_delta.supply_delta = ship_qty;
             cpd.market_delta = arrival_market_delta;
 
-            // Note: const WorldState — we cannot push directly.
-            // In the real orchestrator, the cross_province_delta_buffer
-            // is writable. For the V1 prototype, we record the market
-            // delta directly in the DeltaBuffer, tagged for future-tick
-            // application. The orchestrator handles the timing.
-            //
-            // For testability, emit the supply delta as a cross-province
-            // entry. The test framework can verify the delta was created.
-            delta.market_deltas.push_back(arrival_market_delta);
+            delta.cross_province_deltas.push_back(cpd);
 
             remaining -= ship_qty;
         }

--- a/simulation/modules/supply_chain/supply_chain_module.cpp
+++ b/simulation/modules/supply_chain/supply_chain_module.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <cmath>
 
+#include "core/good_id_hash.h"
 #include "core/rng/deterministic_rng.h"
 #include "core/world_state/delta_buffer.h"
 #include "core/world_state/world_state.h"
@@ -18,12 +19,7 @@ namespace econlife {
 // ===========================================================================
 
 uint32_t SupplyChainModule::good_id_from_string(const std::string& good_id_str) {
-    // Deterministic hash — must match ProductionModule::good_id_from_string.
-    uint32_t hash = 0;
-    for (char c : good_id_str) {
-        hash = hash * 31 + static_cast<uint32_t>(c);
-    }
-    return hash;
+    return good_id_hash(good_id_str);
 }
 
 uint32_t SupplyChainModule::compute_transit_ticks(const RouteProfile& route, float mode_speed,

--- a/simulation/tests/benchmarks/CMakeLists.txt
+++ b/simulation/tests/benchmarks/CMakeLists.txt
@@ -8,4 +8,6 @@ target_link_libraries(econlife_benchmarks PRIVATE
     econlife_modules
 )
 
-catch_discover_tests(econlife_benchmarks)
+catch_discover_tests(econlife_benchmarks
+    PROPERTIES LABELS "benchmark"
+)

--- a/simulation/tests/benchmarks/tick_benchmark.cpp
+++ b/simulation/tests/benchmarks/tick_benchmark.cpp
@@ -18,6 +18,7 @@
 #include "core/tick/drain_deferred_work.h"
 #include "core/world_state/apply_deltas.h"
 #include "modules/persistence/persistence_module.h"
+#include "modules/register_base_game_modules.h"
 
 using namespace econlife;
 using namespace econlife::test;
@@ -31,6 +32,26 @@ TEST_CASE("full tick performance at 2000 NPCs", "[benchmark][tick]") {
     ThreadPool pool(6);
 
     BENCHMARK("full tick 2000 NPCs 6 provinces (no modules)") {
+        orch.execute_tick(world, pool);
+        return world.current_tick;
+    };
+}
+
+// ── Contract benchmark: all base modules registered ─────────────────────────
+// This is the real performance contract from CLAUDE.md: tick < 500ms at
+// 2000 significant NPCs, target < 200ms on 6 cores. The "no modules" case
+// above measures orchestrator + state management only; this case exercises
+// the full 27-step module pipeline end to end.
+TEST_CASE("full tick with all modules at 2000 NPCs", "[benchmark][tick][contract]") {
+    auto world = create_test_world(42, 2000, 6, 15);
+    TickOrchestrator orch;
+    PackageConfig config{};
+    register_base_game_modules(orch, config);
+    orch.set_config(config);
+    orch.finalize_registration();
+    ThreadPool pool(6);
+
+    BENCHMARK("contract: 2000 NPCs 6 provinces all base modules") {
         orch.execute_tick(world, pool);
         return world.current_tick;
     };

--- a/simulation/tests/determinism/CMakeLists.txt
+++ b/simulation/tests/determinism/CMakeLists.txt
@@ -8,4 +8,6 @@ target_link_libraries(econlife_determinism_tests PRIVATE
     econlife_modules
 )
 
-catch_discover_tests(econlife_determinism_tests)
+catch_discover_tests(econlife_determinism_tests
+    PROPERTIES LABELS "determinism"
+)

--- a/simulation/tests/integration/CMakeLists.txt
+++ b/simulation/tests/integration/CMakeLists.txt
@@ -11,5 +11,7 @@ target_link_libraries(econlife_integration_tests PRIVATE
 
 # PROPERTIES SKIP_RETURN_CODE 4 tells CTest that exit code 4 (Catch2 SKIP) is not a failure.
 catch_discover_tests(econlife_integration_tests
-    PROPERTIES SKIP_RETURN_CODE 4
+    PROPERTIES
+        SKIP_RETURN_CODE 4
+        LABELS "integration"
 )

--- a/simulation/tests/scenarios/CMakeLists.txt
+++ b/simulation/tests/scenarios/CMakeLists.txt
@@ -12,4 +12,6 @@ target_link_libraries(econlife_scenario_tests PRIVATE
     econlife_modules
 )
 
-catch_discover_tests(econlife_scenario_tests)
+catch_discover_tests(econlife_scenario_tests
+    PROPERTIES LABELS "scenario"
+)

--- a/simulation/tests/test_world_factory.h
+++ b/simulation/tests/test_world_factory.h
@@ -137,7 +137,7 @@ inline NPC create_test_npc(uint32_t id, NPCRole role, uint32_t province_id) {
     npc.movement_follower_count = 0;
     npc.home_province_id = province_id;
     npc.current_province_id = province_id;
-    npc.travel_status = static_cast<NPCTravelStatus>(0);  // resident
+    npc.travel_status = NPCTravelStatus::resident;
     npc.status = NPCStatus::active;
 
     // Balanced motivation vector (sums to 1.0)

--- a/simulation/tests/unit/CMakeLists.txt
+++ b/simulation/tests/unit/CMakeLists.txt
@@ -56,6 +56,7 @@ add_executable(econlife_unit_tests
     recipe_catalog_test.cpp
     facility_type_catalog_test.cpp
     technology_catalog_test.cpp
+    delta_buffer_merge_test.cpp
 )
 
 target_link_libraries(econlife_unit_tests PRIVATE

--- a/simulation/tests/unit/CMakeLists.txt
+++ b/simulation/tests/unit/CMakeLists.txt
@@ -64,4 +64,6 @@ target_link_libraries(econlife_unit_tests PRIVATE
     econlife_interactive_json
 )
 
-catch_discover_tests(econlife_unit_tests)
+catch_discover_tests(econlife_unit_tests
+    PROPERTIES LABELS "module"
+)

--- a/simulation/tests/unit/delta_buffer_merge_test.cpp
+++ b/simulation/tests/unit/delta_buffer_merge_test.cpp
@@ -1,0 +1,236 @@
+// Coverage tests for DeltaBuffer::merge_from and PlayerDelta::merge_from.
+//
+// The "covers every field" test is a tripwire: when a developer adds a
+// new field to DeltaBuffer or PlayerDelta and forgets to update
+// merge_from in delta_buffer.cpp, this test fails. That is the whole
+// point — the orchestrator's province merge silently dropped fields
+// before merge_from existed (npc_business::dissolved_businesses was
+// the live instance that prompted the refactor).
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include "core/world_state/delta_buffer.h"
+
+using namespace econlife;
+using Catch::Matchers::WithinAbs;
+
+namespace {
+
+// Populate every vector field with a single distinguishable entry and
+// every PlayerDelta optional with a value. If you add a new field to
+// DeltaBuffer or PlayerDelta, extend this helper AND the corresponding
+// REQUIRE in test_delta_buffer_merge_covers_every_field.
+void populate_every_field(DeltaBuffer& db, uint32_t tag) {
+    {
+        NPCDelta d{};
+        d.npc_id = tag;
+        db.npc_deltas.push_back(d);
+    }
+
+    db.player_delta.health_delta = static_cast<float>(tag) * 0.1f;
+    db.player_delta.wealth_delta = static_cast<float>(tag) * 1.0f;
+    db.player_delta.exhaustion_delta = static_cast<float>(tag) * 0.01f;
+    {
+        SkillDelta sd{};
+        sd.skill_id = tag;
+        sd.value = static_cast<float>(tag);
+        db.player_delta.skill_delta = sd;
+    }
+    db.player_delta.new_evidence_awareness = tag;
+    {
+        RelationshipDelta rd{};
+        rd.target_npc_id = tag;
+        rd.trust_delta = static_cast<float>(tag);
+        rd.respect_delta = static_cast<float>(tag);
+        db.player_delta.relationship_delta = rd;
+    }
+    db.player_delta.new_province_id = tag;
+    db.player_delta.new_travel_status = NPCTravelStatus::resident;
+
+    {
+        MarketDelta d{};
+        d.good_id = tag;
+        d.region_id = tag;
+        db.market_deltas.push_back(d);
+    }
+    {
+        EvidenceDelta d{};
+        d.retired_token_id = tag;
+        db.evidence_deltas.push_back(d);
+    }
+    {
+        ConsequenceDelta d{};
+        d.new_entry_id = tag;
+        db.consequence_deltas.push_back(d);
+    }
+    {
+        BusinessDelta d{};
+        d.business_id = tag;
+        db.business_deltas.push_back(d);
+    }
+    {
+        RegionDelta d{};
+        d.region_id = tag;
+        db.region_deltas.push_back(d);
+    }
+    {
+        CurrencyDelta d{};
+        d.nation_id = tag;
+        db.currency_deltas.push_back(d);
+    }
+    {
+        TechnologyDelta d{};
+        d.business_id = tag;
+        db.technology_deltas.push_back(d);
+    }
+    {
+        CalendarEntry e{};
+        e.id = tag;
+        db.new_calendar_entries.push_back(e);
+    }
+    {
+        SceneCard s{};
+        s.id = tag;
+        db.new_scene_cards.push_back(s);
+    }
+    {
+        ObligationNode n{};
+        n.creditor_npc_id = tag;
+        db.new_obligation_nodes.push_back(n);
+    }
+    {
+        CrossProvinceDelta d{};
+        d.source_province_id = tag;
+        d.target_province_id = tag + 1;
+        d.due_tick = tag;
+        db.cross_province_deltas.push_back(d);
+    }
+    {
+        DissolvedBusinessDelta d{};
+        d.business_id = tag;
+        db.dissolved_businesses.push_back(d);
+    }
+    {
+        NewBusinessDelta d{};
+        d.new_business.id = tag;
+        db.new_businesses.push_back(d);
+    }
+    {
+        SceneCardChoiceDelta d{};
+        d.scene_card_id = tag;
+        d.chosen_choice_id = tag;
+        db.scene_card_choice_deltas.push_back(d);
+    }
+    {
+        CalendarCommitDelta d{};
+        d.calendar_entry_id = tag;
+        d.committed = true;
+        db.calendar_commit_deltas.push_back(d);
+    }
+}
+
+}  // namespace
+
+TEST_CASE("test_delta_buffer_merge_covers_every_field", "[world_state][delta_buffer]") {
+    DeltaBuffer dst{};
+    populate_every_field(dst, 1);
+
+    DeltaBuffer src{};
+    populate_every_field(src, 2);
+
+    dst.merge_from(std::move(src));
+
+    // Every vector field must have grown from 1 to 2 entries. If a new
+    // DeltaBuffer field is added without merge_from support, the
+    // populate_every_field helper above will be updated too — and the
+    // corresponding line below will fail until merge_from is wired up.
+    REQUIRE(dst.npc_deltas.size() == 2);
+    REQUIRE(dst.market_deltas.size() == 2);
+    REQUIRE(dst.evidence_deltas.size() == 2);
+    REQUIRE(dst.consequence_deltas.size() == 2);
+    REQUIRE(dst.business_deltas.size() == 2);
+    REQUIRE(dst.region_deltas.size() == 2);
+    REQUIRE(dst.currency_deltas.size() == 2);
+    REQUIRE(dst.technology_deltas.size() == 2);
+    REQUIRE(dst.new_calendar_entries.size() == 2);
+    REQUIRE(dst.new_scene_cards.size() == 2);
+    REQUIRE(dst.new_obligation_nodes.size() == 2);
+    REQUIRE(dst.cross_province_deltas.size() == 2);
+    REQUIRE(dst.dissolved_businesses.size() == 2);
+    REQUIRE(dst.new_businesses.size() == 2);
+    REQUIRE(dst.scene_card_choice_deltas.size() == 2);
+    REQUIRE(dst.calendar_commit_deltas.size() == 2);
+
+    // Append order is preserved: the dst-tagged entry comes first.
+    REQUIRE(dst.npc_deltas[0].npc_id == 1);
+    REQUIRE(dst.npc_deltas[1].npc_id == 2);
+    REQUIRE(dst.market_deltas[0].good_id == 1);
+    REQUIRE(dst.market_deltas[1].good_id == 2);
+    REQUIRE(dst.dissolved_businesses[0].business_id == 1);
+    REQUIRE(dst.dissolved_businesses[1].business_id == 2);
+}
+
+TEST_CASE("test_player_delta_merge_additive_and_replacement", "[world_state][delta_buffer]") {
+    PlayerDelta dst{};
+    dst.health_delta = 1.0f;
+    dst.wealth_delta = 100.0f;
+    dst.exhaustion_delta = 0.5f;
+    {
+        SkillDelta sd{};
+        sd.skill_id = 1;
+        sd.value = 1.0f;
+        dst.skill_delta = sd;
+    }
+    dst.new_evidence_awareness = 100;
+    dst.new_province_id = 5;
+    dst.new_travel_status = NPCTravelStatus::resident;
+
+    PlayerDelta src{};
+    src.health_delta = 2.0f;
+    src.wealth_delta = 50.0f;
+    src.exhaustion_delta = 0.25f;
+    {
+        SkillDelta sd{};
+        sd.skill_id = 7;
+        sd.value = 9.0f;
+        src.skill_delta = sd;
+    }
+    src.new_evidence_awareness = 200;
+    src.new_province_id = 9;
+    src.new_travel_status = NPCTravelStatus::in_transit;
+
+    dst.merge_from(std::move(src));
+
+    // Additive sums.
+    REQUIRE_THAT(*dst.health_delta, WithinAbs(3.0f, 0.001f));
+    REQUIRE_THAT(*dst.wealth_delta, WithinAbs(150.0f, 0.001f));
+    REQUIRE_THAT(*dst.exhaustion_delta, WithinAbs(0.75f, 0.001f));
+
+    // Replacement: incoming wins.
+    REQUIRE(dst.skill_delta->skill_id == 7);
+    REQUIRE_THAT(dst.skill_delta->value, WithinAbs(9.0f, 0.001f));
+    REQUIRE(*dst.new_evidence_awareness == 200);
+    REQUIRE(*dst.new_province_id == 9);
+    REQUIRE(*dst.new_travel_status == NPCTravelStatus::in_transit);
+}
+
+TEST_CASE("test_player_delta_merge_seeds_when_dst_empty", "[world_state][delta_buffer]") {
+    // When dst has no value for an additive field but src does, dst
+    // should end up holding src's value (not a sum-of-nothing surprise).
+    PlayerDelta dst{};
+    PlayerDelta src{};
+    src.health_delta = 5.0f;
+    src.new_province_id = 3;
+
+    dst.merge_from(std::move(src));
+
+    REQUIRE(dst.health_delta.has_value());
+    REQUIRE_THAT(*dst.health_delta, WithinAbs(5.0f, 0.001f));
+    REQUIRE(dst.new_province_id.has_value());
+    REQUIRE(*dst.new_province_id == 3);
+
+    // Untouched additive fields stay empty.
+    REQUIRE(!dst.wealth_delta.has_value());
+    REQUIRE(!dst.exhaustion_delta.has_value());
+}

--- a/simulation/tests/unit/price_engine_test.cpp
+++ b/simulation/tests/unit/price_engine_test.cpp
@@ -432,10 +432,11 @@ TEST_CASE("test_module_interface_properties", "[price_engine][tier3]") {
     REQUIRE(module.is_province_parallel() == true);
 
     auto after = module.runs_after();
-    REQUIRE(after.size() == 3);
+    REQUIRE(after.size() == 4);
     REQUIRE(after[0] == "supply_chain");
     REQUIRE(after[1] == "labor_market");
     REQUIRE(after[2] == "seasonal_agriculture");
+    REQUIRE(after[3] == "npc_spending");
 
     auto before = module.runs_before();
     REQUIRE(before.size() == 1);

--- a/simulation/tests/unit/random_events_test.cpp
+++ b/simulation/tests/unit/random_events_test.cpp
@@ -480,7 +480,10 @@ TEST_CASE("test_module_name_and_ordering", "[random_events][tier1]") {
     REQUIRE(module.name() == "random_events");
     REQUIRE(module.package_id() == "base_game");
     REQUIRE(module.scope() == ModuleScope::v1);
-    REQUIRE(module.is_province_parallel() == true);
+    // Module is NOT province-parallel: concurrent execute_province calls
+    // would race on active_events_ (push_back) and next_event_id_ (++).
+    // See random_events_module.cpp::execute() for the rationale.
+    REQUIRE(module.is_province_parallel() == false);
 
     auto after = module.runs_after();
     REQUIRE(after.size() == 1);

--- a/simulation/tests/unit/recipe_catalog_test.cpp
+++ b/simulation/tests/unit/recipe_catalog_test.cpp
@@ -238,16 +238,12 @@ TEST_CASE("RecipeCatalog::validate_against_goods - typo surfaces a clear error",
     // from the iron-only goods catalog). Both must be reported by recipe key
     // so the modder can find the offending CSV row.
     REQUIRE(errors.size() == 2);
-    bool found_wheet =
-        std::any_of(errors.begin(), errors.end(), [](const std::string& s) {
-            return s.find("broken_bake") != std::string::npos &&
-                   s.find("wheet") != std::string::npos;
-        });
-    bool found_bread =
-        std::any_of(errors.begin(), errors.end(), [](const std::string& s) {
-            return s.find("broken_bake") != std::string::npos &&
-                   s.find("bread") != std::string::npos;
-        });
+    bool found_wheet = std::any_of(errors.begin(), errors.end(), [](const std::string& s) {
+        return s.find("broken_bake") != std::string::npos && s.find("wheet") != std::string::npos;
+    });
+    bool found_bread = std::any_of(errors.begin(), errors.end(), [](const std::string& s) {
+        return s.find("broken_bake") != std::string::npos && s.find("bread") != std::string::npos;
+    });
     CHECK(found_wheet);
     CHECK(found_bread);
 }

--- a/simulation/tests/unit/recipe_catalog_test.cpp
+++ b/simulation/tests/unit/recipe_catalog_test.cpp
@@ -2,10 +2,13 @@
 
 #include "core/world_gen/recipe_catalog.h"
 
+#include <algorithm>
 #include <catch2/catch_test_macros.hpp>
 #include <filesystem>
 #include <fstream>
 #include <string>
+
+#include "core/world_gen/goods_catalog.h"
 
 using namespace econlife;
 namespace fs = std::filesystem;
@@ -154,4 +157,97 @@ TEST_CASE("RecipeCatalog - load from directory", "[module][production]") {
 
     // Cleanup.
     fs::remove_all(dir);
+}
+
+// ---------------------------------------------------------------------------
+// validate_against_goods — recipe ↔ goods cross-check
+// ---------------------------------------------------------------------------
+
+namespace {
+
+// Minimal goods CSV with iron_ore, coking_coal, steel — every good_id
+// referenced by VALID_CSV's first recipe ("iron_smelting"). Used to
+// verify the validator silences a clean catalog.
+constexpr const char* IRON_GOODS_CSV =
+    "good_id,display_name,tier,unit,category,base_price,perishable,illegal,era_available\n"
+    "iron_ore,Iron Ore,0,tonne,geological,12.00,false,false,1\n"
+    "coking_coal,Coking Coal,0,tonne,geological,40.00,false,false,1\n"
+    "steel,Steel,1,tonne,metals,500.00,false,false,1\n";
+
+// Recipe whose input "wheet" (typo of "wheat") does not exist anywhere.
+constexpr const char* TYPO_RECIPE_CSV =
+    "recipe_key,facility_type_key,display_name,"
+    "input_1_key,input_1_qty,input_2_key,input_2_qty,"
+    "input_3_key,input_3_qty,input_4_key,input_4_qty,"
+    "output_1_key,output_1_qty,output_1_is_byproduct,"
+    "output_2_key,output_2_qty,output_2_is_byproduct,"
+    "labor_per_tick,energy_per_tick,min_tech_tier,key_technology_node,era_available\n"
+    "broken_bake,bakery,Broken Bake,"
+    "wheet,2,,,,,,,"
+    "bread,1,0,,,0,"
+    "10,1.0,0,,1\n";
+
+GoodsCatalog load_iron_goods(const std::string& dir_name) {
+    auto dir = fs::temp_directory_path() / dir_name;
+    fs::create_directories(dir);
+    {
+        std::ofstream f(dir / "goods_tier0.csv");
+        f << IRON_GOODS_CSV;
+    }
+    GoodsCatalog goods;
+    REQUIRE(goods.load_from_directory(dir.string()));
+    return goods;
+}
+
+}  // namespace
+
+TEST_CASE("RecipeCatalog::validate_against_goods - clean catalog", "[module][production]") {
+    GoodsCatalog goods = load_iron_goods("econlife_test_recipe_validate_clean_goods");
+
+    // Single iron_smelting recipe; all good_ids exist in the goods catalog.
+    auto recipe_path = write_temp_csv(
+        "recipes_validate_clean.csv",
+        "recipe_key,facility_type_key,display_name,"
+        "input_1_key,input_1_qty,input_2_key,input_2_qty,"
+        "input_3_key,input_3_qty,input_4_key,input_4_qty,"
+        "output_1_key,output_1_qty,output_1_is_byproduct,"
+        "output_2_key,output_2_qty,output_2_is_byproduct,"
+        "labor_per_tick,energy_per_tick,min_tech_tier,key_technology_node,era_available\n"
+        "iron_smelting,smelter,Iron Smelting,"
+        "iron_ore,5,coking_coal,2,,,,,"
+        "steel,3,0,,,0,"
+        "80,5.0,2,,1\n");
+    RecipeCatalog recipes;
+    REQUIRE(recipes.load_csv(recipe_path));
+
+    auto errors = recipes.validate_against_goods(goods);
+    CHECK(errors.empty());
+}
+
+TEST_CASE("RecipeCatalog::validate_against_goods - typo surfaces a clear error",
+          "[module][production]") {
+    GoodsCatalog goods = load_iron_goods("econlife_test_recipe_validate_typo_goods");
+
+    auto recipe_path = write_temp_csv("recipes_validate_typo.csv", TYPO_RECIPE_CSV);
+    RecipeCatalog recipes;
+    REQUIRE(recipes.load_csv(recipe_path));
+
+    auto errors = recipes.validate_against_goods(goods);
+
+    // Two missing good_ids: "wheet" (input) and "bread" (output, also absent
+    // from the iron-only goods catalog). Both must be reported by recipe key
+    // so the modder can find the offending CSV row.
+    REQUIRE(errors.size() == 2);
+    bool found_wheet =
+        std::any_of(errors.begin(), errors.end(), [](const std::string& s) {
+            return s.find("broken_bake") != std::string::npos &&
+                   s.find("wheet") != std::string::npos;
+        });
+    bool found_bread =
+        std::any_of(errors.begin(), errors.end(), [](const std::string& s) {
+            return s.find("broken_bake") != std::string::npos &&
+                   s.find("bread") != std::string::npos;
+        });
+    CHECK(found_wheet);
+    CHECK(found_bread);
 }

--- a/simulation/tests/unit/supply_chain_test.cpp
+++ b/simulation/tests/unit/supply_chain_test.cpp
@@ -12,6 +12,7 @@
 #include <string>
 
 #include "core/rng/deterministic_rng.h"
+#include "core/world_state/apply_deltas.h"
 #include "core/world_state/delta_buffer.h"
 #include "core/world_state/world_state.h"
 #include "modules/supply_chain/supply_chain_module.h"
@@ -345,7 +346,9 @@ TEST_CASE("test_transport_cost_deduction_from_business", "[supply_chain][tier2]"
 
 TEST_CASE("test_transit_arrival_adds_to_supply", "[supply_chain][tier2]") {
     // When an inter-province shipment is dispatched, the supply delta
-    // for the destination province should be created.
+    // for the destination province must be queued as a CrossProvinceDelta
+    // with due_tick = current_tick + transit_ticks. It is NOT applied
+    // in the dispatch tick.
     auto state = make_test_world_state();
 
     state.provinces.push_back(make_test_province(0));
@@ -363,11 +366,80 @@ TEST_CASE("test_transit_arrival_adds_to_supply", "[supply_chain][tier2]") {
     DeltaBuffer delta{};
     module.execute_province(0, state, delta);
 
-    // There should be a supply delta for copper in province 0.
-    auto summary = summarize_market_deltas(delta, "copper", 0);
-    REQUIRE(summary.supply_count >= 1);
+    // Same-tick supply must NOT include the cross-province shipment.
+    auto same_tick = summarize_market_deltas(delta, "copper", 0);
+    REQUIRE(same_tick.supply_count == 0);
+
+    // A CrossProvinceDelta carrying the supply must be queued for arrival.
+    uint32_t copper_id = SupplyChainModule::good_id_from_string("copper");
+    float total_delayed_supply = 0.0f;
+    int delayed_count = 0;
+    for (const auto& cpd : delta.cross_province_deltas) {
+        if (cpd.target_province_id != 0) continue;
+        if (!cpd.market_delta.has_value()) continue;
+        const auto& md = *cpd.market_delta;
+        if (md.good_id != copper_id || md.region_id != 0) continue;
+        REQUIRE(cpd.source_province_id == 1);
+        REQUIRE(cpd.due_tick > state.current_tick);
+        if (md.supply_delta.has_value()) {
+            total_delayed_supply += *md.supply_delta;
+            delayed_count++;
+        }
+    }
+    REQUIRE(delayed_count >= 1);
     // Shipped quantity should match the demand (25 units, limited by demand).
-    REQUIRE_THAT(summary.total_supply_delta, WithinAbs(25.0f, 0.01f));
+    REQUIRE_THAT(total_delayed_supply, WithinAbs(25.0f, 0.01f));
+}
+
+TEST_CASE("test_transit_arrival_applies_at_due_tick", "[supply_chain][tier2]") {
+    // End-to-end check: dispatch an inter-province shipment, then drive the
+    // tick orchestrator forward and verify the destination market.supply
+    // increases only when current_tick reaches the queued due_tick.
+    auto state = make_test_world_state();
+
+    state.provinces.push_back(make_test_province(0));
+    state.provinces.push_back(make_test_province(1));
+
+    add_market(state, "copper", 0, 0.0f, 25.0f, 20.0f);
+    add_market(state, "copper", 1, 50.0f, 0.0f, 18.0f);
+    add_route(state, 1, 0, 400.0f);
+    state.npc_businesses.push_back(make_test_business(1, 0, 10000.0f));
+
+    // Capture the destination supply baseline before dispatch.
+    uint32_t copper_id = SupplyChainModule::good_id_from_string("copper");
+    auto find_market = [&](uint32_t province) -> const RegionalMarket* {
+        for (const auto& m : state.regional_markets) {
+            if (m.province_id == province && m.good_id == copper_id) return &m;
+        }
+        return nullptr;
+    };
+    REQUIRE(find_market(0) != nullptr);
+    float baseline_supply = find_market(0)->supply;
+
+    // Dispatch tick: emit the cross-province delta and stage it on WorldState.
+    SupplyChainModule module;
+    DeltaBuffer dispatch_delta{};
+    module.execute_province(0, state, dispatch_delta);
+    REQUIRE(!dispatch_delta.cross_province_deltas.empty());
+
+    uint32_t due_tick = dispatch_delta.cross_province_deltas.front().due_tick;
+    REQUIRE(due_tick > state.current_tick);
+
+    // Stage on WorldState (mirrors what apply_deltas does for cross-province).
+    for (auto& cpd : dispatch_delta.cross_province_deltas) {
+        state.cross_province_delta_buffer.entries.push_back(std::move(cpd));
+    }
+
+    // Step ticks forward; supply must remain unchanged until due_tick.
+    while (state.current_tick < due_tick) {
+        apply_cross_province_deltas(state);
+        REQUIRE_THAT(find_market(0)->supply, WithinAbs(baseline_supply, 0.001f));
+        state.current_tick++;
+    }
+
+    // On the due tick, the entry releases and supply increases.
+    apply_cross_province_deltas(state);
+    REQUIRE_THAT(find_market(0)->supply, WithinAbs(baseline_supply + 25.0f, 0.01f));
 }
 
 TEST_CASE("test_perishable_decay_formula", "[supply_chain][tier2]") {

--- a/simulation/tests/unit/supply_chain_test.cpp
+++ b/simulation/tests/unit/supply_chain_test.cpp
@@ -261,8 +261,8 @@ TEST_CASE("test_transit_time_from_route_profile", "[supply_chain][tier2]") {
     RouteProfile route = make_route(600.0f);  // 600 km
     float infra = 0.5f;
 
-    uint32_t ticks =
-        SupplyChainModule::compute_transit_ticks(route, SupplyChainModuleConfig{}.road_speed, infra);
+    uint32_t ticks = SupplyChainModule::compute_transit_ticks(
+        route, SupplyChainModuleConfig{}.road_speed, infra);
 
     // Expected: ceil(600 / (300 * (1 + 0.5 * 0.5))) = ceil(600 / 375) = ceil(1.6) = 2
     REQUIRE(ticks == 2);
@@ -273,8 +273,8 @@ TEST_CASE("test_transit_time_minimum_one_tick", "[supply_chain][tier2]") {
     RouteProfile route = make_route(10.0f);  // 10 km
     float infra = 1.0f;
 
-    uint32_t ticks =
-        SupplyChainModule::compute_transit_ticks(route, SupplyChainModuleConfig{}.road_speed, infra);
+    uint32_t ticks = SupplyChainModule::compute_transit_ticks(
+        route, SupplyChainModuleConfig{}.road_speed, infra);
 
     // Expected: ceil(10 / (300 * 1.5)) = ceil(0.022) = 1
     REQUIRE(ticks == 1);
@@ -286,10 +286,10 @@ TEST_CASE("test_transit_time_high_infrastructure", "[supply_chain][tier2]") {
     float low_infra = 0.0f;
     float high_infra = 1.0f;
 
-    uint32_t ticks_low =
-        SupplyChainModule::compute_transit_ticks(route, SupplyChainModuleConfig{}.road_speed, low_infra);
-    uint32_t ticks_high =
-        SupplyChainModule::compute_transit_ticks(route, SupplyChainModuleConfig{}.road_speed, high_infra);
+    uint32_t ticks_low = SupplyChainModule::compute_transit_ticks(
+        route, SupplyChainModuleConfig{}.road_speed, low_infra);
+    uint32_t ticks_high = SupplyChainModule::compute_transit_ticks(
+        route, SupplyChainModuleConfig{}.road_speed, high_infra);
 
     // Low infra: ceil(900 / (300 * 1.0)) = 3
     REQUIRE(ticks_low == 3);
@@ -375,10 +375,13 @@ TEST_CASE("test_transit_arrival_adds_to_supply", "[supply_chain][tier2]") {
     float total_delayed_supply = 0.0f;
     int delayed_count = 0;
     for (const auto& cpd : delta.cross_province_deltas) {
-        if (cpd.target_province_id != 0) continue;
-        if (!cpd.market_delta.has_value()) continue;
+        if (cpd.target_province_id != 0)
+            continue;
+        if (!cpd.market_delta.has_value())
+            continue;
         const auto& md = *cpd.market_delta;
-        if (md.good_id != copper_id || md.region_id != 0) continue;
+        if (md.good_id != copper_id || md.region_id != 0)
+            continue;
         REQUIRE(cpd.source_province_id == 1);
         REQUIRE(cpd.due_tick > state.current_tick);
         if (md.supply_delta.has_value()) {
@@ -409,7 +412,8 @@ TEST_CASE("test_transit_arrival_applies_at_due_tick", "[supply_chain][tier2]") {
     uint32_t copper_id = SupplyChainModule::good_id_from_string("copper");
     auto find_market = [&](uint32_t province) -> const RegionalMarket* {
         for (const auto& m : state.regional_markets) {
-            if (m.province_id == province && m.good_id == copper_id) return &m;
+            if (m.province_id == province && m.good_id == copper_id)
+                return &m;
         }
         return nullptr;
     };


### PR DESCRIPTION
## Summary

Multi-pass cleanup of the 2026-03-30 audit and adjacent issues. 12 commits, all green: 1312 ctest cases (+7 new) across module / determinism / scenario / integration / benchmark labels.

### Tier A (concrete bug fixes)
- **Stale tests** — `price_engine_test.cpp:435` (runs_after expected 3, impl/spec have 4) and `random_events_test.cpp:483` (is_province_parallel expected true, impl returns false by design to avoid a documented data race) updated to match the implementations / specs.
- **CI was running zero tests.** `ctest -L "module" / "determinism" / "scenario"` matched zero tests because no `catch_discover_tests()` call set any LABELS. Added LABELS to all four test executables and a new integration step. Every prior green CI run was a no-op.
- **supply_chain inter-province transit-delay bypass.** Module built a `CrossProvinceDelta` with future `due_tick` then ignored it and pushed the inner `MarketDelta` directly into the current-tick buffer — goods arrived instantly. Now pushes the cpd; new test verifies arrival lands at the correct future tick.
- **antitrust evidence-id collisions.** `current_tick*10000 + province_id*100 + good_id%100` collides for `good_id ≥ 100`, `province_id ≥ 100`, or two markets sharing `good_id % 100`; also overlaps `EvidenceModule::next_token_id_`. Replaced with a module-internal counter starting at `1_000_000`.
- **`test_world_factory.h`** literal-cast `static_cast<NPCTravelStatus>(0)` replaced with `NPCTravelStatus::resident`.

### Tier B (architectural)
- **B1: `DeltaBuffer::merge_from`.** Hand-rolled per-field merge in the orchestrator silently dropped four delta types (`dissolved_businesses`, `new_businesses`, `scene_card_choice_deltas`, `calendar_commit_deltas`) — `npc_business::dissolved_businesses` was a live bug. Centralized merge policy into `DeltaBuffer::merge_from` / `PlayerDelta::merge_from`. Tripwire test populates every field and asserts every vector grows after merge.
- **B3: CI performance gate.** New benchmark TEST_CASE registers all 43 base game modules (real contract); workflow runs Release benchmarks, parses Catch2 XML, fails when mean exceeds 200 ms (the design target). Local mean: 5.999 ms. Other benchmarks still runnable locally via `ctest -L benchmark`, ungated for noise reasons.

### H5 (perf): per-id linear scan removal
- `drain_deferred_work` now builds an `unordered_map` lookup index once per drain.
- `LaborMarketModule::find_employment` and `NpcSpendingModule::get_buyer_type` use `mutable` lazy indices keyed by `npc_id`. Init_for_tick maintains the index inline, turning O(NPC²) initialization into O(NPC).

### L-tier
- **L1 (quick):** three modules duplicated `hash * 31 + c` for good_ids with explicit "must match" comments. Consolidated into `core/good_id_hash.h` (FNV-1a). Verified zero collisions on the 247-good base_game catalog.
- **L5:** new `RecipeCatalog::validate_against_goods` cross-checks every recipe's input/output `good_id` against the catalog at world generation. Prints missing references to stderr. Verified clean on base_game (247 goods, 102 recipes).
- **L6:** "Tier N: Depends on X" comments in `register_base_game_modules.cpp` were drifting. Replaced with role-based section groupings; `runs_after()`/`runs_before()` named as the source of truth.

### Documentation
- `docs/CODEBASE_AUDIT_REPORT.md` refreshed: 16 of 25 items resolved with commit SHAs cited; remaining open items priority-ordered.
- `docs/plans/2026-04-25-tier-b-followups.md` for the bigger architectural items.

### Caveat (documented, not blocking)
The L1 hash change emits different uint32 values from the prior `hash * 31 + c`. Persistence serializes good_id as raw uint32 with no schema bump — saves from any pre-`62cf040` build will load (unchanged schema version) but hold IDs that no longer resolve at runtime. V1 is pre-release so no real users are affected. The eventual catalog-numeric-id migration should bump `CURRENT_SCHEMA_VERSION`.

## Test plan
- [x] `ctest --test-dir build -j 4` — 1312 / 1312 pass
- [x] `./econlife_determinism_tests` — 1810 assertions, all pass
- [x] Contract benchmark mean: 5.999 ms (Release, local)
- [x] CI's three lint steps simulated locally:
  - dependency direction (`simulation/` doesn't `#include "ui/"`): clean
  - forbidden randomness (no `std::rand`, `system_clock`, etc.): clean
  - clang-format-17: branch is 16 errors better-formatted than main (771 vs 787); residual is pre-existing baseline that was failing on main already.

https://claude.ai/code/session_013fbgiNaWiGEedS1u4pwQLJ

---
_Generated by [Claude Code](https://claude.ai/code/session_013fbgiNaWiGEedS1u4pwQLJ)_