### PR TITLE
Fix three Windows-only test failures (pre-existing, blocking CI)

### DIFF
--- a/simulation/tests/unit/world_generator_test.cpp
+++ b/simulation/tests/unit/world_generator_test.cpp
@@ -1344,7 +1344,9 @@ TEST_CASE("WorldGenerator - write_world_json creates file on disk", "[world_gen]
 
     auto world = WorldGenerator::generate(config);
 
-    std::string tmp_path = "/tmp/econlife_test_world_" + std::to_string(config.seed) + ".json";
+    std::string tmp_path = (fs::temp_directory_path() /
+                            ("econlife_test_world_" + std::to_string(config.seed) + ".json"))
+                               .string();
     WorldGenerator::write_world_json(world, tmp_path);
 
     // File should exist and be valid JSON.
@@ -1399,7 +1401,7 @@ TEST_CASE("WorldGenerator - JSON nation fields are present", "[world_gen][json_o
 
 TEST_CASE("WorldGenerator - output_world_file config writes during generate",
           "[world_gen][json_output]") {
-    std::string tmp_path = "/tmp/econlife_test_auto_output.json";
+    std::string tmp_path = (fs::temp_directory_path() / "econlife_test_auto_output.json").string();
     fs::remove(tmp_path);  // clean up any prior run
 
     WorldGeneratorConfig config{};
@@ -3694,7 +3696,8 @@ TEST_CASE("WorldGeneratorConfig: default planetary_params are Earth-analog",
     CHECK(config.planetary_params.hydrology_mode == HydrologyMode::Active);
 }
 
-TEST_CASE("WorldGeneratorConfig: default scenario params match spec §11", "[world_gen][scenario]") {
+TEST_CASE("WorldGeneratorConfig: default scenario params match spec section 11",
+          "[world_gen][scenario]") {
     WorldGeneratorConfig config{};
 
     CHECK(config.tectonic_plate_count == 6);


### PR DESCRIPTION
## Summary
Fixes three pre-existing test failures that have been silently breaking `windows-latest` CI since PR #8.

| Test | Cause | Fix |
|---|---|---|
| `WorldGenerator - write_world_json creates file on disk` | hardcoded `/tmp/...` path | `fs::temp_directory_path() / "..."` |
| `WorldGenerator - output_world_file config writes during generate` | hardcoded `/tmp/...` path | `fs::temp_directory_path() / "..."` |
| `WorldGeneratorConfig: default scenario params match spec §11` | `§` (U+00A7) mangled by ctest's CP-1252 filter pass-through on Windows | renamed to `spec section 11` |

The Windows-Linux split went unnoticed because audits ran tests only on Linux. Visible in the failing job log: `No test cases matched '"... -�11"'`.

## Test plan
- [x] Local: 1177/1177 module tests pass on Linux Release
- [x] All 3 targeted tests pass (Linux): `ctest -R "write_world_json|output_world_file|default scenario params"`
- [ ] CI: windows-latest Debug + Release pass (will verify after CI runs)

https://claude.ai/code/session_01Wj6ehECvMRzw67NvJhoNHE

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wj6ehECvMRzw67NvJhoNHE)_